### PR TITLE
allow long passwords and long multi-line comments

### DIFF
--- a/add_password_dialog.ui
+++ b/add_password_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>266</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -38,7 +38,7 @@
    <item>
     <widget class="QLineEdit" name="pwEdit1">
      <property name="maxLength">
-      <number>64</number>
+      <number>512</number>
      </property>
      <property name="echoMode">
       <enum>QLineEdit::Password</enum>
@@ -58,7 +58,7 @@
       <string/>
      </property>
      <property name="maxLength">
-      <number>64</number>
+      <number>512</number>
      </property>
      <property name="echoMode">
       <enum>QLineEdit::Password</enum>
@@ -88,6 +88,20 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Comments</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="commentsEdit">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -121,32 +135,12 @@
    <signal>accepted()</signal>
    <receiver>AddPasswordDialog</receiver>
    <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>257</x>
-     <y>239</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
    <receiver>AddPasswordDialog</receiver>
    <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>325</x>
-     <y>239</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>

--- a/dialogs.py
+++ b/dialogs.py
@@ -68,6 +68,10 @@ class AddPasswordDialog(QtGui.QDialog, Ui_AddPasswordDialog):
 	def pw2(self):
 		return self.pwEdit2.text()
 	
+	def comments(self):
+		doc = self.commentsEdit.document()
+		return doc.toPlainText()
+	
 	def validatePw(self):
 		same = self.pw1() == self.pw2()
 		button = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)


### PR DESCRIPTION
**The big objective was to make Trezorpass more useful by allowing the addition of long, multi-line comments. The idea of multi-line comments was taken from keePass.**

* The GUI was modified to add the TextEdit array for the comments. Comments are always shown in the GUI in plaintext.

* Increased the password field from 64 to 512 letters in the GUI.

* Removed some hints in the GUI layout

* The new implemented size limit allows the password+comments to be up to 4096 bytes long. This limit is artificial, i.e. it could be bigger but for safety I capped it at 4K.

* On the implementation side there were two bottlenecks. a) RSA encryption was limited to 470 bytes, b) Trezor encryption is limited to 1024 bytes. See below.

* To keep the program structure the same, password and comments are stored in a concatenated fashion. Before the key-value pair was "key" and "password". Now the key-value pair is "key" and "concatenated password and comments". Overall the pwdb structure is the same at the high level, but in the detail there is the first minor change because the "value" now represents both password and comments.

* In order to work around the RSA size limit (470 bytes), I split the plain text into junks and encrypted the junks and then stored the reassembled encrypted pieces in the pwdb. On decrypt it works the reverse way, junks are decrypted and the plaintext is reassembled. RSA is usually a bit slow and not ideal, but since we are not encrypting giant sets of data it should not matter performance wise. This was done so I could stick to the original approach taken. Since a safe 466 bytes were taken as block-size it is required that RSA key size is 4096 bits. The PR to change RSA from 2040 to 4096 must be done first.

* In order to work around the 1023 byte user data limit on the Trezor encryt_keyvalue() call, I also split the plain text in to junks, encrypted the junks with Trezor and reassembled an encrypted blob that is stored in the pwdb file. On decrypt it works the reverse way, junks are decrypted and the plaintext is reassembled. 

* Due to the modifications it was necessary to change the pwdb-data-format version from 1 to 2. The implemented version 2 is backward compatible. The version 2 software can open and read a version 1 pwdb file. As a matter of fact, the first thing the software does when it detects a version 1 pwdb file is to convert it to version 2 and store it right away as v2 before allowing the user to do anything else. For safety reasons a backup of the v1 pwdb file is made automatically. 

* The software is not forward compatible, i.e. the version 1 software cannot open a v2 pwdb fie. To open a v2 pwdb file you need the version 2 of the software.

* From a security perspective comments are treated identical to passwords with the only exception being that in the GUI the comments are shown in plaintext once you edit an item.

* just like passwords are cached, comments are cached for performance and convenience reasons

* when exporting a CSV file, then comments form a new additional column
