### PR TITLE
added CSV import functionality

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -121,6 +121,8 @@
     </property>
     <addaction name="actionSave"/>
     <addaction name="actionBackup"/>
+    <addaction name="actionImport"/>
+    <addaction name="actionAbout"/>
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
@@ -138,6 +140,16 @@
   <action name="actionBackup">
    <property name="text">
     <string>Backup/Export</string>
+   </property>
+  </action>
+  <action name="actionImport">
+   <property name="text">
+    <string>Import CSV</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="text">
+    <string>Show Version</string>
    </property>
   </action>
   <action name="actionQuit">


### PR DESCRIPTION
**Added the functionality to import passwords from a CSV file**

* This allows to migrate passwords from other password managers to TrezorPass. E.g. One could export his passwords from KeePass into a CSV file. Then modify this CSV via scripts or by hand such that the resulting CSV file corresponds to the TrezorPass CSV import format. This modified CSV can then be imported into TrezorPass.

* This new functionality reads a properly formated CSV file from disk and adds its contents to the current entries. 
	
* Import format in CSV should be : group, key, password, comments

* There is no special error checking, so be extra careful. 
* Make a backup first. As a matter of fact, TrezorPass automatically makes a backup for you before performing a CSV import.

* Entries from CSV will be *added* to existing pwdb. If this is not desired create an empty pwdb file first.

* GroupNames are unique, so if a groupname exists then key-password-comments tuples are added to the already existing group. If a group name does not exist, a new group is created and the key-password-comments tuples are added to the newly created group.

* Keys are not unique. So key-password-comments are always added.  If a key with a given name existed before and the CSV file contains a key with the same name, then the key-password-comments is added and after the import the given group has 2 keys with the same name. Both keys exist then, the old from before the import, and the new one from the import.

* Examples of valid CSV file format: Some example lines
```
First Bank account,login,myloginname,	# no comment
foo@gmail.com,2-factor-authentication key,abcdef12345678,seed to regenerate 2FA codes
foo@gmail.com,recovery phrase,"passwd with 2 commas , ,",	
foo@gmail.com,large multi-line comments,,"first line, some comma, 
second line"
phone,PIN,1234,my phone PIN
```