### PR TITLE
Pyqt5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
+.*.swp
+*.pyc
+*.kpf
+
+ui_*py
+TrezorPass.pro.user
+trezorlib
+*.pwdb*
+
+Crypto
+
+build/
+dist/
+TrezorPass.spec
 
 trezorpass.csv.org
+
+keepass2.xml
+trezorpass.csv
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,3 @@
-.*.swp
-*.pyc
-*.kpf
 
-ui_*py
-TrezorPass.pro.user
-trezorlib
-*.pwdb*
+trezorpass.csv.org
 
-Crypto
-
-build/
-dist/
-TrezorPass.spec
-
-trezorpass.csv
-keepass2.xml

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 UI_GENERATED := \
-    ui_mainwindow.py \
-    ui_addgroup_dialog.py \
+	ui_main_window.py \
+	ui_initialize_dialog.py \
+    ui_add_group_dialog.py \
+	ui_add_password_dialog.py \
+	ui_trezor_chooser_dialog.py \
+	ui_trezor_pin_dialog.py \
     ui_trezor_passphrase_dialog.py \
-    ui_add_password_dialog.py \
-    ui_initialize_dialog.py \
-    ui_enter_pin_dialog.py \
-    ui_trezor_chooser_dialog.py \
     #end of UI_GENERATED
 
 all: $(UI_GENERATED)
 
 ui_%.py: %.ui
-	pyuic4 -o $@ $<
+	pyuic5 -o $@ $<
 
 
 clean:
-	rm -rf $(UI_GENERATED)
+	rm -f $(UI_GENERATED)
+	rm -f *.pyc
+	rm -rf __pycache__

--- a/README.md
+++ b/README.md
@@ -7,14 +7,10 @@ TrezorPass is a PyQt-based password manager that uses the [Trezor](http://www.tr
 hardware token to do encryption of passwords. It is similar to KeepassX or
 kwalletmanager in function. It can store passwords, logons, URLs, PINs, comments, etc.
 
-The Password database is stored in encrypted form in a single file on computer.
-No access to internet is required for its use. It allows an unlimited
+The Password database is stored in encrypted form in a single file on your computer.
+No access to the internet is required for its use. It allows an unlimited
 count of password entries to be stored and enables the possibility of recovery
 if your original Trezor is misplaced (mnemonic and passphrase are required to recover).
-
-Note that this is alpha software.
-
-Trezor must be already set up to use passphrase.
 
 Below  a sample screenshot. More screenshots [here](screenshots).
 
@@ -45,28 +41,45 @@ Below  a sample screenshot. More screenshots [here](screenshots).
 
 # Runtime requirements
 
-  * Python 2.7
-  * PyCrypto
-  * PyQt4
-  * [trezorlib from python-trezor](https://github.com/trezor/python-trezor)
+* Use of passphrases must have been already enabled on your [Trezor](https://www.trezor.io) device.
+* [Trezor](https://www.trezor.io) device
+* [Python](https://www.python.org/) v2.7 or 3.4+
+* [PyCrypto](https://pypi.python.org/pypi/pycrypto)
+* [PyQt5](https://pypi.python.org/pypi/PyQt5)
+* [Qt5](https://doc.qt.io/qt-5/)
+* [trezorlib from python-trezor](https://github.com/trezor/python-trezor)
+* [Versions 0.5.0 and older used PyQy4 instead of PyQy5. Read the README.md
+file of v0.5.0 for build requirements, dependencies, etc. Basically anything
+relating to PyQt5 has to be replaced with the corresponding component in PyQt4.
+`pyuic5` becomes `pyuic4`. `pyqt5-dev-tools` becomes `pyqt4-dev-tools`
+and so forth.]
 
 # Building
 
-Even though the whole code is in Python, there are few Qt .ui form files that
-need to be transformed into Python files. There's Makefile, you just need to run
+Even though the whole code is in Python, there are few Qt5 `.ui` form files that
+need to be transformed into Python files. There is `Makefile`, you just need to run
 
     make
 
 ## Build requirements
 
-PyQt4 development tools are necessary, namely `pyuic4` (look for packages named
-like `pyqt4-dev-tools` or `PyQt4-devel`).
+* PyQt5 development tools are necessary, namely `pyuic5` (look for a package named
+`pyqt5-dev-tools`, `PyQt5-devel` or similar). Required to run `make`.
+* Depending on one's set-up one might need: `qttools5-dev-tools`
+(also sets up some of the Qt5 environment variables)
+* Depending on one's set-up one might need: `python-pyqt5` (Qt5 bindings for Python 2)
+* Depending on one's set-up one might need: `python3-pyqt5` (Qt5 bindings for Python 3)
+* Depending on one's set-up one might need: `python-pyqt5.qtsvg` (to display SVG logos in Python 2)
+* Depending on one's set-up one might need: `python3-pyqt5.qtsvg` (to display SVG logos in Python 3)
 
 # Running
 
 Run:
 
     python TrezorPass.py
+or
+
+    python3 TrezorPass.py
 
 On rare occasions one of the command line arguments might become useful:
 
@@ -111,6 +124,15 @@ See also [gpg on Trezor](https://github.com/romanz/trezor-agent/).
 
 # FAQ - Frequently Asked Questions
 
+**Question:** Can I help or contribute?
+
+**Answer:**
+
+Yes, you can. It would help a lot if you assist in getting the word out.
+If you like the tool or like the idea please spread the word on Twitter, Reddit,
+Facebook, etc. It will be appreciated. Furthermore, you can blog about it,
+give feedback, review the code, contribute to the code, etc.
+- - -
 **Question:** I read something about an RSA key somewhere? Do I need to
 create it? Can I use my own? Where is it? How many bits is it?
 
@@ -148,7 +170,7 @@ This string is stored in the QQtCore.QSettings.
 - - -
 **Question:** In which language is TrezorPass written?
 
-**Answer:** [Python](https://www.python.org/) 2.7. It will currently not run on Python 3.
+**Answer:** [Python](https://www.python.org/). It run on Python 2.7 and 3.4+.
 - - -
 **Question:** Do I need to have a [Trezor](https://www.trezor.io/) in order to use TrezorPass?
 
@@ -216,7 +238,7 @@ This string is stored in the QQtCore.QSettings.
 - - -
 **Question:** Is TrezorPass portable?
 
-**Answer:** Yes. You can have all information on 2 files: the TrezorPass application and the password database file. Copy the 2 files (executable and data) onto a USB stick or SD card and carry them with you together with your Trezor. (Maybe in the future the files might be stored on the Trezor 2 on-device storage? Who knows?)
+**Answer:** Yes. You can have all information on 2 files: the TrezorPass application and the password database file. Copy the 2 files (executable and data) onto a USB stick or SD card and carry them with you together with your Trezor. (Maybe in the future the files might be stored on the `Trezor 2` on-device storage? Pure speculation but Who knows?)
 - - -
 **Question:** Can I use TrezorPass on multiple computers? Can I sync it on multiple devices/computers?
 
@@ -319,7 +341,7 @@ convertKeePass2XmlToTrezorPassCsv.py [-v] [-h] [-i <keepass2.xml>] [-o <trezorpa
 - - -
 **Question:** What if I lose my password database file?
 
-**Answer:** Then you lost all your passwords. The passwords are **not** stored on the Trezor. The passwords are only stored in the password database file. So keep it safe. (Trezor 2 does not exist yet, but it might come with on-device storage in the future. In this future case you might store a copy of the password database file on the device. But even then you should keep a copy somewhere else as well.)
+**Answer:** Then you lost all your passwords. The passwords are **not** stored on the Trezor. The passwords are only stored in the password database file. So keep it safe. (`Trezor 2` does not exist yet, but it might come with on-device storage in the future. In this future case you might store a copy of the password database file on the device. But even then you should keep a copy somewhere else as well.)
 - - -
 **Question:** Should I backup my password database file?
 
@@ -331,7 +353,22 @@ convertKeePass2XmlToTrezorPassCsv.py [-v] [-h] [-i <keepass2.xml>] [-o <trezorpa
 - - -
 **Question:** On which platforms, operating systems is TrezorPass available?
 
-**Answer:** On all platforms, operating systems where [Python](https://www.python.org/) 2.7 and [PyQt](https://en.wikipedia.org/wiki/PyQt) v4 is available: Windows, Linux, Unix, Mac OS X. Internet searches show Python and PyQt solutions for Android and iOS, but it has not been investigated or tested on Android or iOS.
+**Answer:** On all platforms, operating systems where [Python](https://www.python.org/) 2.7 or 3.4+ and [PyQt](https://en.wikipedia.org/wiki/PyQt) v5 is available: Windows, Linux, Unix, Mac OS X. Internet searches show Python and PyQt solutions for Android and iOS, but it has not been investigated, built or tested on Android or iOS. It was only tested on Linux.
+- - -
+**Question:** Can I run on Qt4?
+
+**Answer:** Yes, there is an old version (v3.0) that supports Qt4. Newer versions do not support PyQt4 but require PyQt5.
+- - -
+**Question:** Can I migrate from Python 2 to Python 3?
+
+**Answer:** Yes, TrezorPass runs on both. So, you easily move your environment from Python 2 to Python 3.
+- - -
+**Question:** Can I migrate from Python 3 back to Python 2?
+
+**Answer:** TrezorPass runs on both but the implementation of `pickle` is different on both versions.
+The TrezorPass passwordd database file uses `pickle`. When you move from Python 3 back to Python 2 and
+then want to run TrezorPass, you will get the error message `Critical: Could not decrypt passwords: unsupported pickle protocol: 4`and the program aborts. The workaround is to export your database to a CSV file in Python 3, then start with
+an empty database file in Python 2 and import the CSV file. Then you are ready to go.
 - - -
 **Question:** Are there any warranties or guarantees?
 
@@ -341,3 +378,14 @@ convertKeePass2XmlToTrezorPassCsv.py [-v] [-h] [-i <keepass2.xml>] [-o <trezorpa
 
 **Answer:** Let us know.
 - - -
+
+# To-do List
+
+- [ ] Add a `Show All` right-click item in the password list to show all passwords and all comments with one click.
+- [ ] Add command line arguments to the CLI such as `--add group key password comment`,
+        `--show group key`, `--showcomments group key` or `--delete group [key]` and using `xsel` even `--paste group key`.
+- [ ] Spread the information about the availability of this tool on social
+networks like Reddit, Twitter or Facebook. Any help appreciated.
+
+
+</> on :octocat: with :heart:

--- a/README.md
+++ b/README.md
@@ -381,11 +381,11 @@ an empty database file in Python 2 and import the CSV file. Then you are ready t
 
 # To-do List
 
+- [ ] Spread the information about the availability of this tool on social
+        networks like Reddit, Twitter or Facebook. Any help appreciated.
 - [ ] Add a `Show All` right-click item in the password list to show all passwords and all comments with one click.
 - [ ] Add command line arguments to the CLI such as `--add group key password comment`,
         `--show group key`, `--showcomments group key` or `--delete group [key]` and using `xsel` even `--paste group key`.
-- [ ] Spread the information about the availability of this tool on social
-networks like Reddit, Twitter or Facebook. Any help appreciated.
-
+- [ ] Add `Rename group` to group menu
 
 </> on :octocat: with :heart:

--- a/TrezorPass.py
+++ b/TrezorPass.py
@@ -7,23 +7,16 @@ from __future__ import print_function
 import sys
 import logging
 import os.path
-import csv
-import time
-from Crypto import Random
 from shutil import copyfile
 
 from PyQt5.QtWidgets import QApplication  # for the clipboard and window
 
 from dialogs import MainWindow
 
-import basics
-import utils
 import settings
-import encoding
 import processing
 import trezor_app_generic
 import password_map
-from backup import Backup
 
 """
 The file with the main function.
@@ -83,7 +76,6 @@ def main():
 	trezor.prefillReadpinfromstdin(sets.TArg)
 	trezor.prefillReadpassphrasefromstdin(sets.TArg)
 	trezor.prefillPassphrase(sets.passphrase())
-	trezor.prefillPassphrase(u'trezorpass')###sremove this line'!!! zzzz
 
 	pwMap = password_map.PasswordMap(trezor, sets)
 

--- a/TrezorPass.py
+++ b/TrezorPass.py
@@ -1,987 +1,132 @@
 #!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import sys
+import logging
 import os.path
 import csv
 import time
-import logging
-
-from PyQt4 import QtGui, QtCore
-from PyQt4.QtCore import QTimer
-from PyQt4.QtGui import QPixmap
 from Crypto import Random
 from shutil import copyfile
 
-from trezorlib.client import BaseClient, ProtocolMixin, CallException, PinException
-from trezorlib.transport import ConnectionError
-from trezorlib.transport_hid import HidTransport
-from trezorlib import messages_pb2 as proto
+from PyQt5.QtWidgets import QApplication  # for the clipboard and window
 
-from ui_mainwindow import Ui_MainWindow
+from dialogs import MainWindow
 
 import basics
+import utils
+import settings
+import encoding
 import processing
+import trezor_app_generic
 import password_map
-from encoding import q2s, s2q
 from backup import Backup
 
-from dialogs import AddGroupDialog, TrezorPassphraseDialog, AddPasswordDialog, \
-	InitializeDialog, EnterPinDialog, TrezorChooserDialog
+"""
+The file with the main function.
 
-class MainWindow(QtGui.QMainWindow, Ui_MainWindow):
-	"""Main window for the application with groups and password lists"""
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
 
-	KEY_IDX = 0 #column where key is shown in password table
-	PASSWORD_IDX = 1 #column where password is shown in password table
-	COMMENTS_IDX = 2 #column where comments is shown in password table
-	NOOFPASSWDTABLECOLUMNS = 3 # 3 columns: key + value/passwd/secret + comments
-	PASSWORDCACHE_IDX = 0 #column of QWidgetItem in whose data we cache decrypted passwords
-	COMMENTSCACHE_IDX = 1 #column of QWidgetItem in whose data we cache decrypted comments
-	# MAXSIZEOFPASSWDANDCOMMENTS limit is arbitrary, could handle larger size, but set to 4K for safety
-	MAXSIZEOFPASSWDANDCOMMENTS = 4096 # artificial limit on the GUI
-	# clear clipboard after CLIPBOARDTIMEOUTINSEC seconds after copy with ^C;
-	# if set to 0 then clipboard will not be cleared
-	# Common user mistake is to not click their Trezor after ^C and then be surprised that their clipboard is empty
-	CLIPBOARDTIMEOUTINSEC = 10 # clear clipboard after 10 seconds
 
-	def __init__(self, pwMap, settings, logger, dbFilename):
-		"""
-		@param pwMap: a PasswordMap instance with encrypted passwords
-		@param dbFilename: file name for saving pwMap
-		"""
-		QtGui.QMainWindow.__init__(self)
-		self.setupUi(self)
-
-		self.logger = logger
-		self.settings = settings
-		self.pwMap = pwMap
-		self.selectedGroup = None
-		self.modified = False #modified flag "Save?" question on exit
-		self.dbFilename = dbFilename
-
-		self.groupsModel = QtGui.QStandardItemModel()
-		self.groupsModel.setHorizontalHeaderLabels(["Password group"])
-		self.groupsFilter = QtGui.QSortFilterProxyModel()
-		self.groupsFilter.setSourceModel(self.groupsModel)
-
-		self.groupsTree.setModel(self.groupsFilter)
-		self.groupsTree.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-		self.groupsTree.customContextMenuRequested.connect(self.showGroupsContextMenu)
-		self.groupsTree.clicked.connect(self.loadPasswordsBySelection)
-		self.groupsTree.selectionModel().selectionChanged.connect(self.loadPasswordsBySelection)
-		self.groupsTree.setSortingEnabled(True)
-
-		self.passwordTable.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-		self.passwordTable.customContextMenuRequested.connect(self.showPasswdContextMenu)
-		self.passwordTable.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
-		self.passwordTable.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
-
-		shortcut = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+C"), self.passwordTable, self.copyPasswordFromSelection)
-		shortcut.setContext(QtCore.Qt.WidgetShortcut)
-
-		self.actionQuit.triggered.connect(self.close)
-		self.actionQuit.setShortcut(QtGui.QKeySequence("Ctrl+Q"))
-		self.actionExport.triggered.connect(self.exportCsv)
-		self.actionImport.triggered.connect(self.importCsv)
-		self.actionBackup.triggered.connect(self.saveBackup)
-		self.actionAbout.triggered.connect(self.printAbout)
-		self.actionSave.triggered.connect(self.saveDatabase)
-		self.actionSave.setShortcut(QtGui.QKeySequence("Ctrl+S"))
-
-		headerKey = QtGui.QTableWidgetItem("Key");
-		headerValue = QtGui.QTableWidgetItem("Password/Value");
-		headerComments = QtGui.QTableWidgetItem("Comments");
-		self.passwordTable.setColumnCount(self.NOOFPASSWDTABLECOLUMNS)
-		self.passwordTable.setHorizontalHeaderItem(self.KEY_IDX, headerKey)
-		self.passwordTable.setHorizontalHeaderItem(self.PASSWORD_IDX, headerValue)
-		self.passwordTable.setHorizontalHeaderItem(self.COMMENTS_IDX, headerComments)
-
-		self.searchEdit.textChanged.connect(self.filterGroups)
-
-		groupNames = self.pwMap.groups.keys()
-		for groupName in groupNames:
-			item = QtGui.QStandardItem(s2q(groupName))
-			self.groupsModel.appendRow(item)
-		self.groupsTree.sortByColumn(0, QtCore.Qt.AscendingOrder)
-
-		self.clipboard = QtGui.QApplication.clipboard()
-
-		self.timer = QTimer()
-		self.timer.timeout.connect(self.clearClipboard)
-
-	def setModified(self, modified):
-		"""
-		Sets the modified flag so that user is notified when exiting
-		with unsaved changes.
-		"""
-		self.modified = modified
-		self.setWindowTitle("TrezorPass" + "*" * int(self.modified))
-
-	def showGroupsContextMenu(self, point):
-		"""
-		Show context menu for group management.
-
-		@param point: point in self.groupsTree where click occured
-		"""
-		self.addGroupMenu = QtGui.QMenu(self)
-		newGroupAction = QtGui.QAction('Add group', self)
-		deleteGroupAction = QtGui.QAction('Delete group', self)
-		self.addGroupMenu.addAction(newGroupAction)
-		self.addGroupMenu.addAction(deleteGroupAction)
-
-		#disable deleting if no point is clicked on
-		proxyIdx = self.groupsTree.indexAt(point)
-		itemIdx = self.groupsFilter.mapToSource(proxyIdx)
-		item = self.groupsModel.itemFromIndex(itemIdx)
-		if item is None:
-			deleteGroupAction.setEnabled(False)
-
-		action = self.addGroupMenu.exec_(self.groupsTree.mapToGlobal(point))
-
-		if action == newGroupAction:
-			self.createGroup()
-		elif action == deleteGroupAction:
-			self.deleteGroup(item)
-
-
-	def showPasswdContextMenu(self, point):
-		"""
-		Show context menu for password management
-
-		@param point: point in self.passwordTable where click occured
-		"""
-		self.passwdMenu = QtGui.QMenu(self)
-		showPasswordAction = QtGui.QAction('Show password', self)
-		copyPasswordAction = QtGui.QAction('Copy password', self)
-		copyPasswordAction.setShortcut(QtGui.QKeySequence( "Ctrl+C"))
-		showCommentsAction = QtGui.QAction('Show comments', self)
-		copyCommentsAction = QtGui.QAction('Copy comments', self)
-		newItemAction = QtGui.QAction('New item', self)
-		deleteItemAction = QtGui.QAction('Delete item', self)
-		editItemAction = QtGui.QAction('Edit item', self)
-		self.passwdMenu.addAction(showPasswordAction)
-		self.passwdMenu.addAction(copyPasswordAction)
-		self.passwdMenu.addSeparator()
-		self.passwdMenu.addAction(showCommentsAction)
-		self.passwdMenu.addAction(copyCommentsAction)
-		self.passwdMenu.addSeparator()
-		self.passwdMenu.addAction(newItemAction)
-		self.passwdMenu.addAction(deleteItemAction)
-		self.passwdMenu.addAction(editItemAction)
-
-		#disable creating if no group is selected
-		if self.selectedGroup is None:
-			newItemAction.setEnabled(False)
-
-		#disable deleting if no point is clicked on
-		item = self.passwordTable.itemAt(point.x(), point.y())
-		if item is None:
-			deleteItemAction.setEnabled(False)
-			showPasswordAction.setEnabled(False)
-			copyPasswordAction.setEnabled(False)
-			showCommentsAction.setEnabled(False)
-			copyCommentsAction.setEnabled(False)
-			editItemAction.setEnabled(False)
-
-		action = self.passwdMenu.exec_(self.passwordTable.mapToGlobal(point))
-		if action == newItemAction:
-			self.createPassword()
-		elif action == deleteItemAction:
-			self.deletePassword(item)
-		elif action == editItemAction:
-			self.editPassword(item)
-		elif action == copyPasswordAction:
-			self.copyPasswordFromItem(item)
-		elif action == showPasswordAction:
-			self.showPassword(item)
-		elif action == copyCommentsAction:
-			self.copyCommentsFromItem(item)
-		elif action == showCommentsAction:
-			self.showComments(item)
-
-
-	def createGroup(self):
-		"""Slot to create a password group.
-		"""
-		dialog = AddGroupDialog(self.pwMap.groups)
-		if not dialog.exec_():
-			return
-
-		groupName = dialog.newGroupName()
-
-		newItem = QtGui.QStandardItem(groupName)
-		self.groupsModel.appendRow(newItem)
-		self.pwMap.addGroup(q2s(groupName))
-
-		#make new item selected to save a few clicks
-		itemIdx = self.groupsModel.indexFromItem(newItem)
-		proxyIdx = self.groupsFilter.mapFromSource(itemIdx)
-		self.groupsTree.selectionModel().select(proxyIdx,
-			QtGui.QItemSelectionModel.ClearAndSelect | QtGui.QItemSelectionModel.Rows)
-		self.groupsTree.sortByColumn(0, QtCore.Qt.AscendingOrder)
-
-		#Make item's passwords loaded so new key-value entries can be created
-		#right away - better from UX perspective.
-		self.loadPasswords(newItem)
-
-		self.setModified(True)
-
-	def deleteGroup(self, item):
-		msgBox = QtGui.QMessageBox(text="Are you sure about delete?")
-		msgBox.setStandardButtons(QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-		res = msgBox.exec_()
-
-		if res != QtGui.QMessageBox.Yes:
-			return
-
-		name = q2s(item.text())
-		self.selectedGroup = None
-		del self.pwMap.groups[name]
-
-		itemIdx = self.groupsModel.indexFromItem(item)
-		self.groupsModel.takeRow(itemIdx.row())
-		self.passwordTable.setRowCount(0)
-		self.groupsTree.clearSelection()
-
-		self.setModified(True)
-
-	def deletePassword(self, item):
-		msgBox = QtGui.QMessageBox(text="Are you sure about delete?")
-		msgBox.setStandardButtons(QtGui.QMessageBox.Yes | QtGui.QMessageBox.No)
-		res = msgBox.exec_()
-
-		if res != QtGui.QMessageBox.Yes:
-			return
-
-		row = self.passwordTable.row(item)
-		self.passwordTable.removeRow(row)
-		group = self.pwMap.groups[self.selectedGroup]
-		group.removeEntry(row)
-
-		self.passwordTable.resizeRowsToContents()
-		self.passwordTable.horizontalHeader().setResizeMode(0, QtGui.QHeaderView.Stretch)
-		self.passwordTable.horizontalHeader().setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
-		self.passwordTable.horizontalHeader().setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
-		self.setModified(True)
-
-	def cachePassword(self, row, password):
-		"""
-		Cache decrypted password for group and row. Cached items are
-		kept as data of QTableWidgetItem so that deletion invalidates
-		cache.
-
-		Cache applies to currently selectedGroup.
-
-		Switching between groups clears the table and thus invalidates
-		cached passwords.
-		"""
-		item = self.passwordTable.item(row, MainWindow.PASSWORDCACHE_IDX)
-		item.setData(QtCore.Qt.UserRole, QtCore.QVariant(s2q(password)))
-
-	def cacheComments(self, row, comments):
-		"""
-		Cache decrypted comments for group and row. Cached items are
-		kept as data of QTableWidgetItem so that deletion invalidates
-		cache.
-
-		Cache applies to currently selectedGroup.
-
-		Switching between groups clears the table and thus invalidates
-		cached comments.
-		"""
-		item = self.passwordTable.item(row, MainWindow.COMMENTSCACHE_IDX)
-		item.setData(QtCore.Qt.UserRole, QtCore.QVariant(s2q(comments)))
-
-	def cachedPassword(self, row):
-		"""
-		Retrieve cached password for given row of currently selected group.
-		Returns password as string or None if no password cached.
-		"""
-		item = self.passwordTable.item(row, MainWindow.PASSWORDCACHE_IDX)
-		cached = item.data(QtCore.Qt.UserRole)
-
-		if cached.isValid():
-			return q2s(cached.toString())
-
-		return None
-
-	def cachedComments(self, row):
-		"""
-		Retrieve cached comments for given row of currently selected group.
-		Returns comments as string or None if no coments cached.
-		"""
-		item = self.passwordTable.item(row, MainWindow.COMMENTSCACHE_IDX)
-		cached = item.data(QtCore.Qt.UserRole)
-
-		if cached.isValid():
-			return q2s(cached.toString())
-
-		return None
-
-	def cachedOrDecryptPassword(self, row):
-		"""
-		Try retrieving cached password for item in given row, otherwise
-		decrypt with Trezor.
-		"""
-		cached = self.cachedPassword(row)
-
-		if cached is not None:
-			return cached
-		else: #decrypt with Trezor
-			group = self.pwMap.groups[self.selectedGroup]
-			pwEntry = group.entry(row)
-			encPwComments = pwEntry[1]
-
-			decryptedPwComments = self.pwMap.decryptPassword(encPwComments, self.selectedGroup)
-			lngth = int(decryptedPwComments[0:4])
-			decryptedPassword = decryptedPwComments[4:4+lngth]
-			decryptedComments = decryptedPwComments[4+lngth:] #while we are at it, cache the comments too
-			self.cachePassword(row, decryptedPassword)
-			self.cacheComments(row, decryptedComments)
-		return decryptedPassword
-
-	def cachedOrDecryptComments(self, row):
-		"""
-		Try retrieving cached comments for item in given row, otherwise
-		decrypt with Trezor.
-		"""
-		cached = self.cachedComments(row)
-
-		if cached is not None:
-			return cached
-		else: #decrypt with Trezor
-			group = self.pwMap.groups[self.selectedGroup]
-			pwEntry = group.entry(row)
-			encPwComments = pwEntry[1]
-
-			decryptedPwComments = self.pwMap.decryptPassword(encPwComments, self.selectedGroup)
-			lngth = int(decryptedPwComments[0:4])
-			decryptedPassword = decryptedPwComments[4:4+lngth]
-			decryptedComments = decryptedPwComments[4+lngth:]
-			self.cachePassword(row, decryptedPassword)
-			self.cacheComments(row, decryptedComments)
-		return decryptedComments
-
-	def showPassword(self, item):
-		#check if this password has been decrypted, use cached version
-		row = self.passwordTable.row(item)
-		try:
-			decryptedPassword = self.cachedOrDecryptPassword(row)
-		except CallException:
-			return
-		item = QtGui.QTableWidgetItem(s2q(decryptedPassword))
-
-		self.cachePassword(row, decryptedPassword)
-		self.passwordTable.setItem(row, self.PASSWORD_IDX, item)
-
-	def showComments(self, item):
-		#check if this password has been decrypted, use cached version
-		row = self.passwordTable.row(item)
-		try:
-			decryptedComments = self.cachedOrDecryptComments(row)
-		except CallException:
-			return
-		item = QtGui.QTableWidgetItem(s2q(decryptedComments))
-
-		self.cacheComments(row, decryptedComments)
-		self.passwordTable.setItem(row, self.COMMENTS_IDX, item)
-
-	def createPassword(self):
-		"""
-		Slot to create key-value password entry.
-		"""
-		if self.selectedGroup is None:
-			return
-		group = self.pwMap.groups[self.selectedGroup]
-		dialog = AddPasswordDialog(self.pwMap.trezor)
-		if not dialog.exec_():
-			return
-
-		rowCount = self.passwordTable.rowCount()
-		self.passwordTable.setRowCount(rowCount+1)
-		item = QtGui.QTableWidgetItem(dialog.key())
-		pwItem = QtGui.QTableWidgetItem("*****")
-		commetsItem = QtGui.QTableWidgetItem("*****")
-		self.passwordTable.setItem(rowCount, self.KEY_IDX, item)
-		self.passwordTable.setItem(rowCount, self.PASSWORD_IDX, pwItem)
-		self.passwordTable.setItem(rowCount, self.COMMENTS_IDX, commetsItem)
-
-		plainPw = q2s(dialog.pw1())
-		plainComments = q2s(dialog.comments())
-		if len(plainPw) + len(plainComments) > self.MAXSIZEOFPASSWDANDCOMMENTS:
-			processing.reportLogging("Password and/or comments too long. "
-				"Combined they must not be larger than %d." %
-				self.MAXSIZEOFPASSWDANDCOMMENTS,
-				logging.CRITICAL, "User IO", self.settings, self.logger)
-			return
-
-		plainPwComments = ("%4d" % len(plainPw)) + plainPw + plainComments
-		encPw = self.pwMap.encryptPassword(plainPwComments, self.selectedGroup)
-		bkupPw = self.pwMap.backupKey.encryptPassword(plainPwComments)
-		group.addEntry(q2s(dialog.key()), encPw, bkupPw)
-
-		self.cachePassword(rowCount, plainPw)
-		self.cacheComments(rowCount, plainComments)
-
-		self.passwordTable.resizeRowsToContents()
-		self.passwordTable.horizontalHeader().setResizeMode(0, QtGui.QHeaderView.Stretch)
-		self.passwordTable.horizontalHeader().setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
-		self.passwordTable.horizontalHeader().setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
-		self.setModified(True)
-
-	def editPassword(self, item):
-		row = self.passwordTable.row(item)
-		group = self.pwMap.groups[self.selectedGroup]
-		try:
-			decrypted = self.cachedOrDecryptPassword(row)
-			decryptedComments = self.cachedOrDecryptComments(row)
-		except CallException:
-			return
-
-		dialog = AddPasswordDialog(self.pwMap.trezor)
-		entry = group.entry(row)
-		dialog.keyEdit.setText(s2q(entry[0]))
-		dialog.pwEdit1.setText(s2q(decrypted))
-		dialog.pwEdit2.setText(s2q(decrypted))
-		doc = QtGui.QTextDocument(s2q(decryptedComments))
-		dialog.commentsEdit.setDocument(doc)
-
-		if not dialog.exec_():
-			return
-
-		item = QtGui.QTableWidgetItem(dialog.key())
-		pwItem = QtGui.QTableWidgetItem("*****")
-		commentsItem = QtGui.QTableWidgetItem("*****")
-		self.passwordTable.setItem(row, self.KEY_IDX, item)
-		self.passwordTable.setItem(row, self.PASSWORD_IDX, pwItem)
-		self.passwordTable.setItem(row, self.COMMENTS_IDX, commentsItem)
-
-		plainPw = q2s(dialog.pw1())
-		plainComments = q2s(dialog.comments())
-		if len(plainPw) + len(plainComments) > self.MAXSIZEOFPASSWDANDCOMMENTS:
-			processing.reportLogging("Password and/or comments too long. "
-				"Combined they must not be larger than %d." %
-				self.MAXSIZEOFPASSWDANDCOMMENTS,
-				logging.CRITICAL, "User IO", self.settings, self.logger)
-			return
-
-		plainPwComments = ("%4d" % len(plainPw)) + plainPw + plainComments
-
-		encPw = self.pwMap.encryptPassword(plainPwComments, self.selectedGroup)
-		bkupPw = self.pwMap.backupKey.encryptPassword(plainPwComments)
-		group.updateEntry(row, q2s(dialog.key()), encPw, bkupPw)
-
-		self.cachePassword(row, plainPw)
-		self.cacheComments(row, plainComments)
-		self.setModified(True)
-
-	def copyPasswordFromSelection(self):
-		"""
-		Copy selected password to clipboard. Password is decrypted if
-		necessary.
-		"""
-		indexes = self.passwordTable.selectedIndexes()
-		if not indexes:
-			return
-
-		#there will be more indexes as the selection is on a row
-		row = indexes[0].row()
-		item = self.passwordTable.item(row, 1)
-		self.copyPasswordFromItem(item)
-
-	def copyPasswordFromItem(self, item):
-		row = self.passwordTable.row(item)
-		try:
-			decryptedPassword = self.cachedOrDecryptPassword(row)
-		except CallException:
-			return
-
-		self.clipboard.setText(s2q(decryptedPassword))
-		# Do not log contents of clipboard, contains secrets!
-		processing.reportLogging("Copied text to clipboard.", logging.DEBUG,
-			"Clipboard", self.settings, self.logger)
-		if self.CLIPBOARDTIMEOUTINSEC >  0:
-			self.timer.start(self.CLIPBOARDTIMEOUTINSEC*1000) # cancels previous timer
-		self.cachePassword(row, decryptedPassword)
-
-	def copyCommentsFromItem(self, item):
-		row = self.passwordTable.row(item)
-		try:
-			decryptedComments = self.cachedOrDecryptComments(row)
-		except CallException:
-			return
-
-		self.clipboard.setText(s2q(decryptedComments))
-		# Do not log contents of clipboard, contains secrets!
-		processing.reportLogging("Copied text to clipboard.", logging.DEBUG,
-			"Clipboard", self.settings, self.logger)
-		if self.CLIPBOARDTIMEOUTINSEC >  0:
-			self.timer.start(self.CLIPBOARDTIMEOUTINSEC*1000) # cancels previous timer
-		self.cachePassword(row, decryptedComments)
-
-	def clearClipboard(self):
-		self.clipboard.clear()
-		self.timer.stop() # cancels previous timer
-		processing.reportLogging("Clipboard cleared.", logging.DEBUG,
-			"Clipboard", self.settings, self.logger)
-
-	def loadPasswords(self, item):
-		"""
-		Slot that should load items for group that has been clicked on.
-		"""
-		#self.passwordTable.clear()
-		name = q2s(item.text())
-		self.selectedGroup = name
-		group = self.pwMap.groups[name]
-		self.passwordTable.setRowCount(len(group.entries))
-		self.passwordTable.setColumnCount(self.NOOFPASSWDTABLECOLUMNS)
-
-		i = 0
-		for key, encValue, bkupValue in group.entries:
-			item = QtGui.QTableWidgetItem(s2q(key))
-			pwItem = QtGui.QTableWidgetItem("*****")
-			commentsItem = QtGui.QTableWidgetItem("*****")
-			self.passwordTable.setItem(i, self.KEY_IDX, item)
-			self.passwordTable.setItem(i, self.PASSWORD_IDX, pwItem)
-			self.passwordTable.setItem(i, self.COMMENTS_IDX, commentsItem)
-			i = i+1
-
-		self.passwordTable.resizeRowsToContents()
-		self.passwordTable.horizontalHeader().setResizeMode(0, QtGui.QHeaderView.Stretch)
-		self.passwordTable.horizontalHeader().setResizeMode(1, QtGui.QHeaderView.ResizeToContents)
-		self.passwordTable.horizontalHeader().setResizeMode(2, QtGui.QHeaderView.ResizeToContents)
-
-	def loadPasswordsBySelection(self):
-		proxyIdx = self.groupsTree.currentIndex()
-		itemIdx = self.groupsFilter.mapToSource(proxyIdx)
-		selectedItem = self.groupsModel.itemFromIndex(itemIdx)
-
-		if not selectedItem:
-			return
-
-		self.loadPasswords(selectedItem)
-
-	def filterGroups(self, substring):
-		"""
-		Filter groupsTree view to have items containing given substring.
-		"""
-		self.groupsFilter.setFilterFixedString(substring)
-		self.groupsTree.sortByColumn(0, QtCore.Qt.AscendingOrder)
-
-	def printAbout(self):
-		"""
-		Show window with about and version information.
-		"""
-		msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Information, "About", "About <b>TrezorPass</b>: <br><br>TrezorPass is a safe " +
-			"Password Manager application for people owning a Trezor who prefer to " +
-			"keep their passwords local and not on the cloud. All passwords are " +
-			"stored locally in a single file.<br><br>" +
-			"<b>Version: </b>" + basics.VERSION_STR +
-			" from " + basics.VERSION_DATE_STR)
-		msgBox.setIconPixmap(QPixmap("icons/TrezorPass.svg"))
-		msgBox.exec_()
-
-	def saveBackup(self):
-		"""
-		First it saves any pending changes to the pwdb database file. Then it uses an operating system call
-		to copy the file appending a timestamp at the end of the file name.
-		"""
-		if self.modified:
-			self.saveDatabase()
-		backupFilename = settings.dbFilename + "." + time.strftime('%Y%m%d%H%M%S')
-		copyfile(settings.dbFilename, backupFilename)
-		processing.reportLogging("Backup of the encrypted database file has been created "
-			"and placed into file \"%s\" (%d bytes)." % (backupFilename, os.path.getsize(backupFilename)),
-			logging.INFO, "User IO", self.settings, self.logger)
-
-	def importCsv(self):
-		"""
-		Read a properly formated CSV file from disk
-		and add its contents to the current entries.
-
-		Import format in CSV should be : group, key, password, comments
-
-		There is no error checking, so be extra careful.
-
-		Make a backup first.
-
-		Entries from CSV will be *added* to existing pwdb. If this is not desired
-		create an empty pwdb file first.
-
-		GroupNames are unique, so if a groupname exists then
-		key-password-comments tuples are added to the already existing group.
-		If a group name does not exist, a new group is created and the
-		key-password-comments tuples are added to the newly created group.
-
-		Keys are not unique. So key-password-comments are always added.
-		If a key with a given name existed before and the CSV file contains a
-		key with the same name, then the key-password-comments is added and
-		after the import the given group has 2 keys with the same name.
-		Both keys exist then, the old from before the import, and the new one from the import.
-
-		Examples of valid CSV file format: Some example lines
-		First Bank account,login,myloginname,	# no comment
-		foo@gmail.com,2-factor-authentication key,abcdef12345678,seed to regenerate 2FA codes	# with comment
-		foo@gmail.com,recovery phrase,"passwd with 2 commas , ,",	# with comma
-		foo@gmail.com,large multi-line comments,,"first line, some comma,
-		second line"
-		"""
-		if self.modified:
-			self.saveDatabase()
-		copyfile(settings.dbFilename, settings.dbFilename + ".beforeCsvImport.backup")
-		processing.reportLogging("WARNING: You are about to import entries from a "
-			"CSV file into your current password-database file. For safety "
-			"reasons please make a backup copy now.", logging.NOTSET,
-			"CSV import", self.settings, self.logger)
-		dialog = QtGui.QFileDialog(self, "Select import CSV file",
-			"", "CVS files (*.csv)")
-		dialog.setAcceptMode(QtGui.QFileDialog.AcceptOpen)
-
-		res = dialog.exec_()
-		if not res:
-			return
-
-		fname = q2s(dialog.selectedFiles()[0])
-		with file(fname, "r") as f:
-			csv.register_dialect("escaped", doublequote=False, escapechar='\\')
-			reader = csv.reader(f, dialect="escaped")
-			for csvEntry in reader:
-				processing.reportLogging("CSV Entry: len=%d 0=%s" % (len(csvEntry), csvEntry[0]),
-					logging.DEBUG, "CSV import", self.settings, self.logger)
-				processing.reportLogging("CSV Entry: 0=%s, 1=%s, 2=%s, 3=%s" %
-					(csvEntry[0], csvEntry[1], csvEntry[2], csvEntry[3]), logging.DEBUG,
-					"CSV import", self.settings, self.logger)
-				groupName, key, plainPw, plainComments = csvEntry[0], csvEntry[1], csvEntry[2], csvEntry[3]
-				groupNames = self.pwMap.groups.keys()
-				if groupName not in groupNames:  # groups are unique
-					self.pwMap.addGroup(groupName)
-					item = QtGui.QStandardItem(s2q(groupName))
-					self.groupsModel.appendRow(item)
-
-				if len(plainPw) + len(plainComments) > self.MAXSIZEOFPASSWDANDCOMMENTS:
-					processing.reportLogging("Password and/or comments too long. "
-						"Combined they must not be larger than %d." % self.MAXSIZEOFPASSWDANDCOMMENTS, logging.NOTSET,
-						"CSV import", self.settings, self.logger)
-					return
-				group = self.pwMap.groups[groupName]
-				plainPwComments = ("%4d" % len(plainPw)) + plainPw + plainComments
-				encPw = self.pwMap.encryptPassword(plainPwComments, groupName)
-				bkupPw = self.pwMap.backupKey.encryptPassword(plainPwComments)
-				group.addEntry(key, encPw, bkupPw)  # keys are not unique, multiple items with same key are allowed
-			self.groupsTree.sortByColumn(0, QtCore.Qt.AscendingOrder)
-			self.setModified(True)
-
-		processing.reportLogging("Trezorpass has finished importing CSV file "
-			"from \"%s\" into \"%s\"." % (fname, settings.dbFilename), logging.INFO,
-			"CSV import", self.settings, self.logger)
-
-	def exportCsv(self):
-		"""
-		Uses backup key encrypted by Trezor to decrypt all passwords
-		at once and export them into a single paintext CSV file.
-
-		Export format is CSV: group, key, password, comments
-		"""
-		processing.reportLogging("WARNING: During backup/export all passwords will be "
-			"written in plaintext to disk. If possible you should consider performing this "
-			"operation on an offline or air-gapped computer. Be aware of the risks.",
-			logging.NOTSET,	"CSV export", self.settings, self.logger)
-		dialog = QtGui.QFileDialog(self, "Select backup export file",
-			"", "CVS files (*.csv)")
-		dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
-
-		res = dialog.exec_()
-		if not res:
-			return
-
-		fname = q2s(dialog.selectedFiles()[0])
-		backupKey = self.pwMap.backupKey
-		try:
-			privateKey = backupKey.unwrapPrivateKey()
-		except CallException:
-			return
-
-		with file(fname, "w") as f:
-			csv.register_dialect("escaped", doublequote=False, escapechar='\\')
-			writer = csv.writer(f, dialect="escaped")
-			sortedGroupNames = sorted(self.pwMap.groups.keys())
-			for groupName in sortedGroupNames:
-				group = self.pwMap.groups[groupName]
-				for entry in group.entries:
-					key, _, bkupPw = entry
-					decryptedPwComments = backupKey.decryptPassword(bkupPw, privateKey)
-					lngth = int(decryptedPwComments[0:4])
-					password = decryptedPwComments[4:4+lngth]
-					comments = decryptedPwComments[4+lngth:]
-					csvEntry = (groupName, key, password, comments)
-					writer.writerow(csvEntry)
-
-		processing.reportLogging("Trezorpass has finished exporting CSV file "
-			"from \"%s\" to \"%s\"." % (settings.dbFilename, fname), logging.INFO,
-			"CSV export", self.settings, self.logger)
-
-	def saveDatabase(self):
-		"""
-		Save main database file.
-		"""
-		self.pwMap.save(self.dbFilename)
-		self.setModified(False)
-
-	def closeEvent(self, event):
-		if self.modified:
-			msgBox = QtGui.QMessageBox(text="Password database is modified. Save on exit?")
-			msgBox.setStandardButtons(QtGui.QMessageBox.Yes |
-				QtGui.QMessageBox.No | QtGui.QMessageBox.Cancel )
-			reply = msgBox.exec_()
-
-			if not reply or reply == QtGui.QMessageBox.Cancel:
-				event.ignore()
-				return
-			elif reply == QtGui.QMessageBox.Yes:
-				self.saveDatabase()
-
-		event.accept()
-
-class QtTrezorMixin(object):
+def showGui(trezor, app, dialog, settings):
 	"""
-	Mixin for input of passhprases.
-	"""
+	Start the main window.
+	Stay in the main window until the user quits.
 
-	def __init__(self, *args, **kwargs):
-		super(QtTrezorMixin, self).__init__(*args, **kwargs)
-		self.passphrase = None
-
-	def callback_ButtonRequest(self, msg):
-		return proto.ButtonAck()
-
-	def callback_PassphraseRequest(self, msg):
-		if self.passphrase is not None:
-			return proto.PassphraseAck(passphrase=self.passphrase)
-
-		dialog = TrezorPassphraseDialog()
-		if not dialog.exec_():
-			sys.exit(3)
-		else:
-			passphrase = dialog.passphraseEdit.text()
-			passphrase = unicode(passphrase)
-
-		return proto.PassphraseAck(passphrase=passphrase)
-
-	def callback_PinMatrixRequest(self, msg):
-		dialog = EnterPinDialog()
-		if not dialog.exec_():
-			sys.exit(7)
-
-		pin = q2s(dialog.pin())
-		return proto.PinMatrixAck(pin=pin)
-
-	def prefillPassphrase(self, passphrase):
-		"""
-		Instead of asking for passphrase, use this one
-		"""
-		self.passphrase = passphrase.decode("utf-8")
-
-class QtTrezorClient(ProtocolMixin, QtTrezorMixin, BaseClient):
-	"""
-	Trezor client with Qt input methods
-	"""
-	pass
-
-class TrezorChooser(object):
-	"""Class for working with Trezor device via HID"""
-
-	def __init__(self):
-		pass
-
-	def getDevice(self):
-		"""
-		Get one from available devices. Widget will be shown if more
-		devices are available.
-		"""
-		devices = self.enumerateHIDDevices()
-
-		if not devices:
-			return None
-
-		transport = self.chooseDevice(devices)
-		client = QtTrezorClient(transport)
-
-		return client
-
-	def enumerateHIDDevices(self):
-		"""Returns Trezor HID devices"""
-		devices = HidTransport.enumerate()
-
-		return devices
-
-	def chooseDevice(self, devices):
-		"""
-		Choose device from enumerated list. If there's only one Trezor,
-		that will be chosen.
-
-		If there are multiple Trezors, diplays a widget with list
-		of Trezor devices to choose from.
-
-		@returns HidTransport object of selected device
-		"""
-		if not len(devices):
-			raise RuntimeError("No Trezor connected!")
-
-		if len(devices) == 1:
-			try:
-				return HidTransport(devices[0])
-			except IOError:
-				raise RuntimeError("Trezor is currently in use")
-
-
-		#maps deviceId string to device label
-		deviceMap = {}
-		for device in devices:
-			try:
-				transport = HidTransport(device)
-				client = QtTrezorClient(transport)
-				label = client.features.label and client.features.label or "<no label>"
-				client.close()
-
-				deviceMap[device[0]] = label
-			except IOError:
-				#device in use, do not offer as choice
-				continue
-
-		if not deviceMap:
-			raise RuntimeError("All connected Trezors are in use!")
-
-		dialog = TrezorChooserDialog(deviceMap)
-		if not dialog.exec_():
-			sys.exit(9)
-
-		deviceStr = dialog.chosenDeviceStr()
-		return HidTransport([deviceStr, None])
-
-
-def initializeStorage(trezor, pwMap, settings):
-	"""
-	Initialize new encrypted password file, ask for master passphrase.
-
-	Initialize RSA keypair for backup, encrypt private RSA key using
-	backup passphrase and Trezor's cipher-key-value system.
-
-	Makes sure a session is created on Trezor so that the passphrase
-	will be cached until disconnect.
+	Makes sure a session is created on Trezor.
 
 	@param trezor: Trezor client
-	@param pwMap: PasswordMap where to put encrypted backupKeys
-	@param settings: Settings object to store password database location
+	@param dialog: the GUI window
+	@param settings: Settings object to store input and output
+		also holds any necessary settings
 	"""
-	dialog = InitializeDialog()
-	if settings.passphrase() != None:
-		dialog.setPw1(settings.passphrase())
-		dialog.setPw2(settings.passphrase())
+	settings.settings2Gui(dialog)
+	dialog.show()
+	if not app.exec_():
+		# Esc or exception or Quit/Close/Done
+		settings.mlogger.log("Shutting down due to user request "
+			"(Done/Quit was called).", logging.DEBUG, "GUI IO")
+		# sys.exit(4)
+	settings.gui2Settings(dialog)
 
-	if not dialog.exec_():
-		sys.exit(4)
 
-	masterPassphrase = q2s(dialog.pw1())
-
-	trezor.prefillPassphrase(masterPassphrase)
-	backup = Backup(trezor)
-	backup.generate()
-	pwMap.backupKey = backup
-	settings.dbFilename = q2s(dialog.pwFile())
-	settings.FArg = q2s(dialog.pwFile())
-	settings.store()
-
-def updatePwMapFromV1ToV2(pwMap, settings):
+def useTerminal(pwMap, settings):
 	"""
-	Update the pwMap from v1 (only password) to v2 (password and comments).
+	Currently there are no terminal-only functins or a
+	Terminal-mode, but one could envision one in the future
+	with commands like:
+		-t --rm groupName [key]
+		-t --mv groupNameOld groupNameNew
+		-t --add groupName [key password comments]
 	"""
-	backupKey = pwMap.backupKey
-	try:
-		privateKey = backupKey.unwrapPrivateKey()
-	except CallException:
-		return
+	settings.mlogger.log(u"Entering Terminal mode. GUI wil not be called.",
+		logging.DEBUG, u"Arguments")
 
-	for groupName in pwMap.groups.keys():
-		group = pwMap.groups[groupName]
-		for entry in group.entries:
-			key, encryptedPw, bkupPw = entry
-			plainPw = backupKey.decryptPassword(bkupPw, privateKey)
-			plainPwComments = ("%4d" % len(plainPw)) + plainPw
-			encPw = pwMap.encryptPassword(plainPwComments, groupName)
-			bkupPw = pwMap.backupKey.encryptPassword(plainPwComments)
-			idx = group.entries.index(entry)
-			group.updateEntry(idx, key, encPw, bkupPw)
-	pwMap.save(settings.dbFilename)
-	processing.reportLogging("Trezorpass database \"%s\" successfully "
-		"updated from version 1 to version 2." % settings.dbFilename, logging.NOTSET,
-		"Trezor datbase", settings, settings.logger)
 
-# root
+def main():
+	# Terminal-mode is not yet implemented, set it to True once it is
+	terminalModeImplemented = False
+	app = QApplication(sys.argv)
+	sets = settings.Settings()  # initialize settings
+	# parse command line
+	args = settings.Args(sets)
+	args.parseArgs(sys.argv[1:])
 
-logging.basicConfig(stream=sys.stderr, level=basics.DEFAULT_LOG_LEVEL)
-logger = logging.getLogger('tp') # tp for TrezorPass
+	trezor = trezor_app_generic.setupTrezor(sets.TArg, sets.mlogger)
+	# trezor.clear_session() ## not needed
+	trezor.prefillReadpinfromstdin(sets.TArg)
+	trezor.prefillReadpassphrasefromstdin(sets.TArg)
+	trezor.prefillPassphrase(sets.passphrase())
+	trezor.prefillPassphrase(u'trezorpass')###sremove this line'!!! zzzz
 
-app = QtGui.QApplication(sys.argv)
+	pwMap = password_map.PasswordMap(trezor, sets)
 
-settings = processing.Settings(logger) # initialize settings
-# parse command line
-processing.parseArgs(sys.argv[1:], settings, logger)
+	if sets.TArg and terminalModeImplemented:
+		sets.mlogger.log(u"Terminal mode --terminal was set. Avoiding GUI.",
+			logging.INFO, u"Arguments")
+	else:
+		# our GUI does not have a status textBrowser Widget
+		# we do not log to the GUI
+		sets.mlogger.setQtextbrowser(None)
+		dialog = MainWindow(None, sets, sets.dbFilename)
+		# sets.mlogger.setQtextheader(dialog.descrHeader())
+		# sets.mlogger.setQtextcontent(dialog.descrContent())
+		# sets.mlogger.setQtexttrailer(dialog.descrTrailer())
 
-try:
-	trezorChooser = TrezorChooser()
-	trezor = trezorChooser.getDevice()
-except (ConnectionError, RuntimeError), e:
-	processing.reportLogging("Connection to Trezor failed: %s" % e.message,
-		logging.CRITICAL, "Trezor Error", settings, logger)
-	sys.exit(1)
+	sets.mlogger.log("Trezor label: %s" % trezor.features.label,
+		logging.DEBUG, "Trezor IO")
+	sets.mlogger.log("Click 'Confirm' on Trezor to give permission "
+		"whenever required.", logging.DEBUG, "Trezor IO")
 
-if trezor is None:
-	processing.reportLogging("No available Trezor found, quitting.",
-		logging.CRITICAL, "Trezor Error", settings, logger)
-	sys.exit(1)
+	if sets.dbFilename and os.path.isfile(sets.dbFilename):
+		pwMap.loadWithChecks(sets.dbFilename)
 
-trezor.clear_session()
-logger.info("Trezor label: %s", trezor.features.label)
-if settings.passphrase() != None:
-	trezor.prefillPassphrase(settings.passphrase())
+		if pwMap.version == 1:
+			copyfile(sets.dbFilename, sets.dbFilename + ".v1.backup")
+			sets.mloggeer.log("Updating Trezorpass database file from "
+				"version 1 to version 2. Please make a backup of \"%s\" now!" %
+				(sets.dbFilename), logging.NOTSET,
+				"Trezor datbase")
+			processing.updatePwMapFromV1ToV2(pwMap, sets)
+	else:
+		processing.initializeStorage(trezor, pwMap, sets)
 
-pwMap = password_map.PasswordMap(trezor)
+	if sets.TArg and terminalModeImplemented:
+		useTerminal(pwMap, sets)
+	else:
+		# user wants GUI, so we call the GUI
+		dialog.setPwMap(pwMap)
+		showGui(trezor, app, dialog, sets)
+	# cleanup
+	sets.mlogger.log("Cleaning up before shutting down.", logging.DEBUG, "Info")
+	trezor.close()
 
-if settings.dbFilename and os.path.isfile(settings.dbFilename):
-	try:
-		pwMap.load(settings.dbFilename)
-	except PinException:
-		processing.reportLogging("Invalid Trezor PIN entered. Aborting.",
-			logging.CRITICAL, "Trezor IO", settings, logger)
-		sys.exit(8)
-	except CallException:
-		# this is never reached, there is a sys.exit in the Cancel button
-		processing.reportLogging("User requested to quit (Esc, Cancel).",
-			logging.CRITICAL, "Trezor IO", settings, logger)
-		#button cancel on Trezor, so exit
-		sys.exit(6)
-	except Exception, e:
-		processing.reportLogging("Could not decrypt passwords: %s" % e.message,
-			logging.CRITICAL, "Trezor IO", settings, logger)
-		sys.exit(5)
 
-	if pwMap.version == 1:
-		copyfile(settings.dbFilename, settings.dbFilename + ".v1.backup")
-		processing.reportLogging("Updating Trezorpass database file from "
-			"version 1 to version 2. Please make a backup of \"%s\" now!" %
-			settings.dbFilename, logging.NOTSET,
-			"Trezor datbase", settings, logger)
-		updatePwMapFromV1ToV2(pwMap, settings)
-
-else:
-	initializeStorage(trezor, pwMap, settings)
-
-rng = Random.new()
-pwMap.outerIv = rng.read(password_map.BLOCKSIZE)
-pwMap.outerKey = rng.read(password_map.KEYSIZE)
-pwMap.encryptedBackupKey = ""
-
-mainWindow = MainWindow(pwMap, settings, logger, settings.dbFilename)
-mainWindow.show()
-retCode = app.exec_()
-
-sys.exit(retCode)
+if __name__ == '__main__':
+	main()

--- a/add_group_dialog.ui
+++ b/add_group_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>124</height>
+    <height>200</height>
    </rect>
   </property>
   <property name="maximumSize">
@@ -24,6 +24,58 @@
     <normaloff>icons/TrezorPass.svg</normaloff>icons/TrezorPass.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="maximumSize">
+        <size>
+         <width>49</width>
+         <height>64</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap>icons/TrezorPass.svg</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
    <item>
     <widget class="QLabel" name="label">
      <property name="text">

--- a/add_password_dialog.ui
+++ b/add_password_dialog.ui
@@ -25,9 +25,61 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="maximumSize">
+        <size>
+         <width>49</width>
+         <height>64</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap>icons/TrezorPass.svg</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Key</string>
+      <string>Key/Identifier</string>
      </property>
     </widget>
    </item>
@@ -41,7 +93,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>Password/value</string>
+      <string>Password/Value</string>
      </property>
     </widget>
    </item>

--- a/backup.py
+++ b/backup.py
@@ -1,37 +1,45 @@
-import cPickle
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+try:
+	import cPickle as pickle
+except:
+	import pickle
 
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_OAEP
 from Crypto.Cipher import AES
 from Crypto import Random
 
-from encoding import Magic, Padding
+import encoding
+from basics import Magic
+
 
 class Backup(object):
 	"""
 	Performs backup and restore for password storage
 	"""
-	
-	RSA_KEYSIZE = 4096 # in bits
+
+	RSA_KEYSIZE = 4096  # in bits
 	SYMMETRIC_KEYSIZE = 32
 	BLOCKSIZE = 16
-	RSABLOCKSIZE = RSA_KEYSIZE / 8 # in bytes
-	SAFERSABLOCKSIZEWITHOUTBUFFER = RSABLOCKSIZE - 2 - 2 * 32 # 446 # 4096 / 8 - 2 - 2*32
+	RSA_BLOCKSIZE = RSA_KEYSIZE // 8  # in bytes
+	SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER = RSA_BLOCKSIZE - 2 - 2 * 32  # 446 # 4096 // 8 - 2 - 2*32
 
-	
 	def __init__(self, trezor):
 		"""
 		Create with no keys prepared.
-		
+
 		@param trezor: Trezor client object to use for encrypting private
 			key
 		"""
-		self.encryptedPrivate = None #encrypted private key
-		self.encryptedEphemeral = None #ephemeral key used to encrypt private RSA key
-		self.ephemeralIv = None #IV used to encrypt private key with ephemeral key
+		self.encryptedPrivate = None  # encrypted private key
+		self.encryptedEphemeral = None  # ephemeral key used to encrypt private RSA key
+		self.ephemeralIv = None  # IV used to encrypt private key with ephemeral key
 		self.publicKey = None
 		self.trezor = trezor
-	
+
 	def generate(self):
 		"""
 		Generate key and encrypt private key
@@ -40,63 +48,69 @@ class Backup(object):
 		privateDer = key.exportKey(format="DER")
 		self.publicKey = key.publickey()
 		self.wrapPrivateKey(privateDer)
-		
+
 	def wrapPrivateKey(self, privateKey):
 		"""
 		Wrap serialized private key by encrypting it with trezor.
 		"""
-		#Trezor client won't allow to encrypt whole serialized RSA key
-		#in one go - it's too big. We need an ephemeral symmetric key
-		#and encrypt the small ephemeral with Trezor.
+		"""
+		Trezor client won't allow to encrypt whole serialized RSA key
+		in one go - it's too big. We need an ephemeral symmetric key
+		and encrypt the small ephemeral with Trezor.
+		"""
 		rng = Random.new()
 		ephemeral = rng.read(self.SYMMETRIC_KEYSIZE)
 		self.ephemeralIv = rng.read(self.BLOCKSIZE)
 		cipher = AES.new(ephemeral, AES.MODE_CBC, self.ephemeralIv)
 		padded = Padding(self.BLOCKSIZE).pad(privateKey)
 		self.encryptedPrivate = cipher.encrypt(padded)
-		
+
 		self.encryptedEphemeral = self.trezor.encrypt_keyvalue(
 			Magic.backupNode, Magic.backupKey, ephemeral,
 			ask_on_encrypt=False, ask_on_decrypt=True)
-	
+
 	def unwrapPrivateKey(self):
 		"""
 		Decrypt private RSA key using self.encryptedEphemeral from
 		self.encryptedPrivate.
-		
+
 		Encrypted ephemeral key will be decrypted with Trezor.
-		
+
 		@returns RSA private key as Crypto.RSA._RSAobj
 		"""
 		ephemeral = self.trezor.decrypt_keyvalue(Magic.backupNode,
 			Magic.backupKey, self.encryptedEphemeral,
 			ask_on_encrypt=False, ask_on_decrypt=True)
-		
+
 		cipher = AES.new(ephemeral, AES.MODE_CBC, self.ephemeralIv)
 		padded = cipher.decrypt(self.encryptedPrivate)
 		privateDer = Padding(self.BLOCKSIZE).unpad(padded)
-		
+
 		privateKey = RSA.importKey(privateDer)
 		return privateKey
-	
+
 	def serialize(self):
 		"""
 		Return object data as serialized string.
 		"""
 		publicDer = self.publicKey.exportKey(format="DER")
 		picklable = (self.ephemeralIv, self.encryptedEphemeral,
-		     self.encryptedPrivate, publicDer)
-		return cPickle.dumps(picklable, cPickle.HIGHEST_PROTOCOL)
+			self.encryptedPrivate, publicDer)
+		return pickle.dumps(picklable, pickle.HIGHEST_PROTOCOL)
 
 	def deserialize(self, serialized):
 		"""
 		Set object data from serialized string
 		"""
-		unpickled = cPickle.loads(serialized)
+		# Py2-vs-Py3: loads in Py2 does only have 1 arg, all 4 args are required for Py3
+		try:  # Py2-vs-Py3:
+			unpickled = pickle.loads(serialized, fix_imports=True, encoding='bytes', errors='strict')
+		except Exception:
+			unpickled = pickle.loads(serialized)
 		(self.ephemeralIv, self.encryptedEphemeral,
-		     self.encryptedPrivate, publicDer) = unpickled
+			self.encryptedPrivate, publicDer) = unpickled
 		self.publicKey = RSA.importKey(publicDer)
-	
+
 	def encryptPassword(self, password):
 		"""
 		Encrypt password with RSA under OAEP padding and return it.
@@ -104,33 +118,42 @@ class Backup(object):
 		length.
 
 		With a 4096 bit RSA key that results in a maximum length of
-		470 bytes for the plaintext for this implementation (4096/8-2*hashsize-2).
+		470 bytes for the plaintext for this implementation (4096//8-2*hashsize-2).
+
+		@param password: password entry, key/value pair
+		@type pasword: string (unicode)
+		@returns: encrypted passwords of type bytes
 		"""
 		cipher = PKCS1_OAEP.new(self.publicKey)
 		# With a 4096 bit RSA key PKCS1_OAEP.cipher.encrypt() has as limit a maximum
-		# length of 470 bytes for the plaintext in this implementation 
-		# (4096/8-2*hashsize-2).
+		# length of 470 bytes for the plaintext in this implementation
+		# (4096//8-2*hashsize-2).
 		# The resulting encrypted block is of size 512 bytes.
 		# To allow larger plain text we junk the plaintext into 446 byte pieces
-		# (so that it would work also in the future with larger hashsizes). 
+		# (so that it would work also in the future with larger hashsizes).
 		# RSA-only is not ideal, but should be acceptable.
 		# See https://security.stackexchange.com/questions/33434
-		encrypted = ""
-		splits=[password[x:x+self.SAFERSABLOCKSIZEWITHOUTBUFFER] for x in range(0,len(password),self.SAFERSABLOCKSIZEWITHOUTBUFFER)]
+		encrypted = b''
+		passwordBytes = encoding.tobytes(password)
+		splits=[passwordBytes[x:x+self.SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER]
+			for x in range(0,len(passwordBytes),self.SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER)]
 		for junk in splits:
 			encrypted += cipher.encrypt(junk)
-		# print "RSA PKCS encryption: plain-size =", len(password), ", encrypted-size =", len(encrypted)
+		# print "RSA PKCS encryption: plain-size =", len(passwordBytes), ", encrypted-size =", len(encrypted)
 		return encrypted
-	
+
 	def decryptPassword(self, encryptedPassword, privateKey):
 		"""
 		Decrypt RSA-OAEP encrypted password.
+		@param encryptedPassword: encrypted password entry, key/value pair
+		@type encryptedPassword: bytes
+		@returns: decrypted pasword of type string (unicode)
 		"""
 		cipher = PKCS1_OAEP.new(privateKey)
-		password = ""
-		splits=[encryptedPassword[x:x+self.RSABLOCKSIZE] for x in range(0,len(encryptedPassword),self.RSABLOCKSIZE)]
+		passwordBytes = b''
+		splits=[encryptedPassword[x:x+self.RSA_BLOCKSIZE]
+			for x in range(0,len(encryptedPassword),self.RSA_BLOCKSIZE)]
 		for junk in splits:
-			password += cipher.decrypt(junk)
-		
-		return password
+			passwordBytes += cipher.decrypt(junk)
 
+		return(encoding.normalize_nfc(passwordBytes))

--- a/backup.py
+++ b/backup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 try:
 	import cPickle as pickle
-except:
+except Exception:
 	import pickle
 
 from Crypto.PublicKey import RSA
@@ -62,7 +62,7 @@ class Backup(object):
 		ephemeral = rng.read(self.SYMMETRIC_KEYSIZE)
 		self.ephemeralIv = rng.read(self.BLOCKSIZE)
 		cipher = AES.new(ephemeral, AES.MODE_CBC, self.ephemeralIv)
-		padded = Padding(self.BLOCKSIZE).pad(privateKey)
+		padded = encoding.Padding(self.BLOCKSIZE).pad(privateKey)
 		self.encryptedPrivate = cipher.encrypt(padded)
 
 		self.encryptedEphemeral = self.trezor.encrypt_keyvalue(
@@ -84,7 +84,7 @@ class Backup(object):
 
 		cipher = AES.new(ephemeral, AES.MODE_CBC, self.ephemeralIv)
 		padded = cipher.decrypt(self.encryptedPrivate)
-		privateDer = Padding(self.BLOCKSIZE).unpad(padded)
+		privateDer = encoding.Padding(self.BLOCKSIZE).unpad(padded)
 
 		privateKey = RSA.importKey(privateDer)
 		return privateKey
@@ -135,8 +135,8 @@ class Backup(object):
 		# See https://security.stackexchange.com/questions/33434
 		encrypted = b''
 		passwordBytes = encoding.tobytes(password)
-		splits=[passwordBytes[x:x+self.SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER]
-			for x in range(0,len(passwordBytes),self.SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER)]
+		splits = [passwordBytes[x:x+self.SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER]
+			for x in range(0, len(passwordBytes), self.SAFE_RSA_BLOCKSIZE_WITHOUTBUFFER)]
 		for junk in splits:
 			encrypted += cipher.encrypt(junk)
 		# print "RSA PKCS encryption: plain-size =", len(passwordBytes), ", encrypted-size =", len(encrypted)
@@ -151,8 +151,8 @@ class Backup(object):
 		"""
 		cipher = PKCS1_OAEP.new(privateKey)
 		passwordBytes = b''
-		splits=[encryptedPassword[x:x+self.RSA_BLOCKSIZE]
-			for x in range(0,len(encryptedPassword),self.RSA_BLOCKSIZE)]
+		splits = [encryptedPassword[x:x+self.RSA_BLOCKSIZE]
+			for x in range(0, len(encryptedPassword), self.RSA_BLOCKSIZE)]
 		for junk in splits:
 			passwordBytes += cipher.decrypt(junk)
 

--- a/basics.py
+++ b/basics.py
@@ -14,7 +14,7 @@ default values, etc.
 NAME = u'TrezorPass'
 
 # Name of software version
-VERSION_STR = u'v4.0'
+VERSION_STR = u'v4.1'
 
 # Date of software version
 VERSION_DATE_STR = u'June 2017'

--- a/basics.py
+++ b/basics.py
@@ -14,7 +14,7 @@ default values, etc.
 NAME = u'TrezorPass'
 
 # Name of software version
-VERSION_STR = u'v4.1'
+VERSION_STR = u'v4.2'
 
 # Date of software version
 VERSION_DATE_STR = u'June 2017'

--- a/basics.py
+++ b/basics.py
@@ -1,14 +1,76 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import logging
+from encoding import unpack
 
-# file extension for encrypted files with plaintext filename
-PWDB_FILEEXT = ".pwdb"
+"""
+This file contains some constant variables like version numbers,
+default values, etc.
+"""
 
-# Data storage version, format of PWDB file
-PWDB_FILEFORMAT_VERSION = 2
+# Name of application
+NAME = u'TrezorPass'
 
-# Name of software version, shown in GUI
-VERSION_STR = "3.2"
-VERSION_DATE_STR = "May 2017"
+# Name of software version
+VERSION_STR = u'v4.0'
+
+# Date of software version
+VERSION_DATE_STR = u'June 2017'
 
 # default log level
 DEFAULT_LOG_LEVEL = logging.INFO  # CRITICAL, ERROR, WARNING, INFO, DEBUG
+
+# short acronym used for name of logger
+LOGGER_ACRONYM = u'tp'
+
+# location of logo image
+LOGO_IMAGE = u'icons/TrezorPass.svg'
+
+# file extension for encrypted files with plaintext filename
+PWDB_FILEEXT = u'.pwdb'
+
+# Data storage version, format of PWDB file
+# Very important for compatibility.
+# Version 1 stores only the password in the value part of the key-value pair
+# Version 2 stores password and comments in the value part of the key-value pair
+# Version 2 software opens a version 1 pwdb file and stores it as version 2;
+#           version 1 software cannot open a version 2 pwdb file.
+#           i.e. v2 is backwards compatible (v2 software can open v1 dbpw file)
+#           but not forwards compatible (v1 software cannot open v2 dbpw file).
+PWDB_FILEFORMAT_VERSION = 2
+
+# size limit of the combined password + commens length
+# MAX_SIZE_OF_PASSWDANDCOMMENTS limit is arbitrary,
+# could handle larger size, but set to 4K for safety
+# GUI .ui file also has a safety restriction
+MAX_SIZE_OF_PASSWDANDCOMMENTS = 4096
+
+# clear clipboard after CLIPBOARD_TIMEOUT_IN_SEC seconds after copy with ^C;
+# if set to 0 then clipboard will not be cleared
+# Common user mistake is to not click their Trezor after ^C and
+# then be surprised that their clipboard is empty
+CLIPBOARD_TIMEOUT_IN_SEC = 10  # clear clipboard after 10 seconds
+
+
+class Magic(object):
+    """
+    Few magic constant definitions so that we know which nodes to search
+    for keys.
+    """
+
+    headerStr = b'TZPW'
+    hdr = unpack("!I", headerStr)
+
+    # for unlocking wrapped AES-CBC key
+    unlockNode = [hdr, unpack("!I", b'ULCK')]
+    # for generating keys for individual password groups
+    groupNode = [hdr, unpack("!I", b'GRUP')]
+    # the unlock and backup key is written in this weird way to fit display nicely
+    unlockKey = b'Decrypt master  key?'  # string to derive wrapping key from
+
+    # for unlocking wrapped backup private RSA key
+    backupNode = [hdr, unpack("!I", b'BKUP')]
+    # string to derive backup wrapping key from
+    backupKey = b'Decrypt backup  key?'

--- a/convertKeePass2XmlToTrezorPassCsv.py
+++ b/convertKeePass2XmlToTrezorPassCsv.py
@@ -125,7 +125,7 @@ def calculateDepth(member, currDepth):
 	return max
 
 
-def printCvs(ofile):
+def printCsv(ofile):
 	with open(ofile, 'r') as f:
 		csv.register_dialect('escaped', doublequote=False, escapechar='\\')
 		reader = csv.reader(f, dialect='escaped')
@@ -160,7 +160,7 @@ def writeEntriesToList(member, currDepth, currGroupName, max, entry_list, csvwri
 			mname = u'--' + mname
 		writeEntriesToList(submember, currDepth+1, currGroupName + mname, max, entry_list, csvwriter)
 	for submember in member.findall('Entry'):
-		dict = {}
+		mydict = {}
 		for strmember in submember.findall('String'):
 			#  ET.dump(submember)  # Debug
 			entry = []
@@ -170,17 +170,17 @@ def writeEntriesToList(member, currDepth, currGroupName, max, entry_list, csvwri
 			except Exception:
 				print('Info: No value given for key "%s" (group: %s), moving on ...' % (mkey, currGroupName))
 				mval = u''
-			dict[mkey] = mval
+			mydict[mkey] = mval
 
 		entry = []
 		sep = u''
 		if currGroupName != u'':
 			sep = u'--'
 
-		entry.append(escape(currGroupName + sep + dict['Title']))
+		entry.append(escape(currGroupName + sep + mydict['Title']))
 		entry.append(u'UserName')
-		if u'UserName' in dict:
-			entry.append(escape(dict['UserName']))
+		if u'UserName' in mydict:
+			entry.append(escape(mydict['UserName']))
 		else:
 			entry.append(u'')
 		entry.append(u'')
@@ -188,10 +188,10 @@ def writeEntriesToList(member, currDepth, currGroupName, max, entry_list, csvwri
 		entry_list.append(entry)
 
 		entry = []
-		entry.append(escape(currGroupName + sep + dict['Title']))
+		entry.append(escape(currGroupName + sep + mydict['Title']))
 		entry.append(u'Password')
-		if u'Password' in dict:
-			entry.append(escape(dict['Password']))
+		if u'Password' in mydict:
+			entry.append(escape(mydict['Password']))
 		else:
 			entry.append(u'')
 		entry.append(u'')
@@ -199,10 +199,10 @@ def writeEntriesToList(member, currDepth, currGroupName, max, entry_list, csvwri
 		entry_list.append(entry)
 
 		entry = []
-		entry.append(escape(currGroupName + sep + dict['Title']))
+		entry.append(escape(currGroupName + sep + mydict['Title']))
 		entry.append(u'URL')
-		if u'URL' in dict:
-			entry.append(escape(dict['URL']))
+		if u'URL' in mydict:
+			entry.append(escape(mydict['URL']))
 		else:
 			entry.append(u'')
 		entry.append(u'')
@@ -210,11 +210,11 @@ def writeEntriesToList(member, currDepth, currGroupName, max, entry_list, csvwri
 		entry_list.append(entry)
 
 		entry = []
-		entry.append(escape(currGroupName + sep + dict['Title']))
+		entry.append(escape(currGroupName + sep + mydict['Title']))
 		entry.append(u'Notes')
 		entry.append(u'')
-		if u'Notes' in dict:
-			entry.append(escape(dict['Notes']))
+		if u'Notes' in mydict:
+			entry.append(escape(mydict['Notes']))
 		else:
 			entry.append(u'')
 		entry_list.append(entry)
@@ -231,8 +231,8 @@ def writeEntriesToList(member, currDepth, currGroupName, max, entry_list, csvwri
 			for el in entry:
 				entryunicode.append(el.encode('utf-8'))
 			csvwriter.writerow(entryunicode)
-		dict.clear()
-		del dict
+		mydict.clear()
+		del mydict
 
 
 def main():
@@ -260,7 +260,7 @@ def main():
 
 	print('Produced output file "%s".' % ofile)
 	print('Entries are in 4 columns as follows: Groupname, Key, Value/Password, Comments')
-	# printCvs(ofile)  # Debug
+	# printCsv(ofile)  # Debug
 
 
 if __name__ == '__main__':

--- a/dialogs.py
+++ b/dialogs.py
@@ -145,12 +145,9 @@ class AddPasswordDialog(QDialog, Ui_AddPasswordDialog):
 		self.trezor = trezor
 
 	def key(self):
-		print('zzz key "%s" %s' % (encoding.normalize_nfc(self.keyEdit.text()), type(encoding.normalize_nfc(self.keyEdit.text()))))
 		return encoding.normalize_nfc(self.keyEdit.text())
 
 	def pw1(self):
-		print('zzz pw1 "%s" %s' % (encoding.normalize_nfc(self.pwEdit1.text()), type(encoding.normalize_nfc(self.pwEdit1.text()))))
-		print('zzz ty %s %s' % (self.pwEdit1.text(), type(self.pwEdit1.text())))
 		return encoding.normalize_nfc(self.pwEdit1.text())
 
 	def pw2(self):
@@ -158,12 +155,10 @@ class AddPasswordDialog(QDialog, Ui_AddPasswordDialog):
 
 	def comments(self):
 		doc = self.commentsEdit.document().toPlainText()
-		print('zzz doc %s.' % doc)
 		if doc is None:
 			doc = u''
 		else:
 			doc = encoding.normalize_nfc(doc)
-		print('zzz doc %s.' % doc)
 		return doc
 
 	def validatePw(self):

--- a/dialogs.py
+++ b/dialogs.py
@@ -1,121 +1,54 @@
-from PyQt4 import QtGui, QtCore
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
+import logging
 import os
 import base64
 import hashlib
+from shutil import copyfile
+import csv
+import time
+import sys
 
-from ui_addgroup_dialog import Ui_AddGroupDialog
-from ui_trezor_passphrase_dialog import Ui_TrezorPassphraseDialog
-from ui_add_password_dialog import Ui_AddPasswordDialog
+from PyQt5.QtWidgets import QApplication, QMainWindow, QDialog, QDialogButtonBox
+from PyQt5.QtWidgets import QMessageBox, QFileDialog, QLineEdit, QShortcut
+from PyQt5.QtWidgets import QAbstractItemView, QTableWidgetItem
+from PyQt5.QtWidgets import QMenu, QAction, QHeaderView
+from PyQt5.QtGui import QPixmap, QKeySequence, QTextDocument, QStandardItem
+from PyQt5.QtGui import QStandardItemModel
+from PyQt5.QtCore import QT_VERSION_STR, QTimer, QDir, Qt, QVariant
+from PyQt5.QtCore import QSortFilterProxyModel, QItemSelectionModel
+from PyQt5.Qt import PYQT_VERSION_STR
+
+from trezorlib.client import CallException
+
 from ui_initialize_dialog import Ui_InitializeDialog
-from ui_enter_pin_dialog import Ui_EnterPinDialog
-from ui_trezor_chooser_dialog import Ui_TrezorChooserDialog
+from ui_add_group_dialog import Ui_AddGroupDialog
+from ui_add_password_dialog import Ui_AddPasswordDialog
+from ui_main_window import Ui_MainWindow
 
 import basics
-from encoding import q2s, s2q
+import encoding
 
-class AddGroupDialog(QtGui.QDialog, Ui_AddGroupDialog):
+"""
+This code should cover the GUI of the business logic of the application.
 
-	def __init__(self, groups):
-		QtGui.QDialog.__init__(self)
-		self.setupUi(self)
-		self.newGroupEdit.textChanged.connect(self.validate)
-		self.groups = groups
-
-		#disabled for empty string
-		button = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
-		button.setEnabled(False)
-
-	def newGroupName(self):
-		return self.newGroupEdit.text()
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
 
 
-	def validate(self):
-		"""
-		Validates input if name is not empty and is different from
-		existing group names.
-		"""
-		valid = True
-		text = self.newGroupEdit.text()
-		if text.isEmpty():
-			valid = False
-
-		if unicode(text).encode("utf-8") in self.groups:
-			valid = False
-
-		button = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
-		button.setEnabled(valid)
-
-class TrezorPassphraseDialog(QtGui.QDialog, Ui_TrezorPassphraseDialog):
+class InitializeDialog(QDialog, Ui_InitializeDialog):
 
 	def __init__(self):
-		QtGui.QDialog.__init__(self)
+		super(InitializeDialog, self).__init__()
+
+		# Set up the user interface from Designer.
 		self.setupUi(self)
 
-	def passphrase(self):
-		return self.passphraseEdit.text()
-
-	def setPassphrase(self, pw):
-		self.passphraseEdit.setText(pw)
-
-class AddPasswordDialog(QtGui.QDialog, Ui_AddPasswordDialog):
-
-	def __init__(self, trezor):
-		QtGui.QDialog.__init__(self)
-		self.setupUi(self)
-		self.pwEdit1.textChanged.connect(self.validatePw)
-		self.pwEdit2.textChanged.connect(self.validatePw)
-		self.showHideButton.clicked.connect(self.switchPwVisible)
-		self.generatePasswordButton.clicked.connect(self.generatePassword)
-		self.trezor = trezor
-
-	def key(self):
-		return self.keyEdit.text()
-
-	def pw1(self):
-		return self.pwEdit1.text()
-
-	def pw2(self):
-		return self.pwEdit2.text()
-
-	def comments(self):
-		doc = self.commentsEdit.document()
-		return doc.toPlainText()
-
-	def validatePw(self):
-		same = self.pw1() == self.pw2()
-		button = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
-		button.setEnabled(same)
-
-	def switchPwVisible(self):
-		pwMode = self.pwEdit1.echoMode()
-		if pwMode == QtGui.QLineEdit.Password:
-			newMode = QtGui.QLineEdit.Normal
-		else:
-			newMode = QtGui.QLineEdit.Password
-
-		self.pwEdit1.setEchoMode(newMode)
-		self.pwEdit2.setEchoMode(newMode)
-
-	def generatePassword(self):
-		trezor_entropy = self.trezor.get_entropy(32)
-		urandom_entropy = os.urandom(32)
-		passwdBin = hashlib.sha256(trezor_entropy + urandom_entropy).digest()
-		# base85 encoding not yet implemented in Python 2.7, (requires Python 3+)
-		# so we use base64 encoding
-		# remove the base64 buffer char =, remove easily confused chars 0 and O, as well as I and l
-		passwdB64 = base64.urlsafe_b64encode(passwdBin).translate(None, '=0OIl')
-		# print "bin =", passwdBin, ", base =", passwdB64, " binlen =", len(passwdBin), "baselen =", len(passwdB64)
-		# instead of setting the values, we concatenate them to the existing values
-		# This way, by clicking the "Generate password" button one can create an arbitrary long random password.
-		self.pwEdit1.setText(self.pw1() + s2q(passwdB64))
-		self.pwEdit2.setText(self.pw2() + s2q(passwdB64))
-
-class InitializeDialog(QtGui.QDialog, Ui_InitializeDialog):
-
-	def __init__(self):
-		QtGui.QDialog.__init__(self)
-		self.setupUi(self)
+		# Make some local modifications.
 		self.masterEdit1.textChanged.connect(self.validate)
 		self.masterEdit2.textChanged.connect(self.validate)
 		self.pwFileEdit.textChanged.connect(self.validate)
@@ -123,19 +56,19 @@ class InitializeDialog(QtGui.QDialog, Ui_InitializeDialog):
 		self.validate()
 
 	def setPw1(self, pw):
-		self.masterEdit1.setText(s2q(pw))
+		self.masterEdit1.setText(encoding.normalize_nfc(pw))
 
 	def setPw2(self, pw):
-		self.masterEdit2.setText(s2q(pw))
+		self.masterEdit2.setText(encoding.normalize_nfc(pw))
 
 	def pw1(self):
-		return self.masterEdit1.text()
+		return encoding.normalize_nfc(self.masterEdit1.text())
 
 	def pw2(self):
-		return self.masterEdit2.text()
+		return encoding.normalize_nfc(self.masterEdit2.text())
 
 	def pwFile(self):
-		return self.pwFileEdit.text()
+		return encoding.normalize_nfc(self.pwFileEdit.text())
 
 	def validate(self):
 		"""
@@ -143,8 +76,8 @@ class InitializeDialog(QtGui.QDialog, Ui_InitializeDialog):
 		without typo and some password file is selected.
 		"""
 		same = self.pw1() == self.pw2()
-		fileSelected = not self.pwFileEdit.text().isEmpty()
-		button = self.buttonBox.button(QtGui.QDialogButtonBox.Ok)
+		fileSelected = (self.pwFileEdit.text() != u'')
+		button = self.buttonBox.button(QDialogButtonBox.Ok)
 		button.setEnabled(same and fileSelected)
 
 	def selectPwFile(self):
@@ -152,10 +85,10 @@ class InitializeDialog(QtGui.QDialog, Ui_InitializeDialog):
 		Show file dialog and return file user chose to store the
 		encrypted password database.
 		"""
-		path = QtCore.QDir.currentPath()
-		dialog = QtGui.QFileDialog(self, "Select password database file",
+		path = QDir.currentPath()
+		dialog = QFileDialog(self, u"Select password database file",
 			path, "(*"+basics.PWDB_FILEEXT+")")
-		dialog.setAcceptMode(QtGui.QFileDialog.AcceptSave)
+		dialog.setAcceptMode(QFileDialog.AcceptSave)
 
 		res = dialog.exec_()
 		if not res:
@@ -164,52 +97,822 @@ class InitializeDialog(QtGui.QDialog, Ui_InitializeDialog):
 		fname = dialog.selectedFiles()[0]
 		self.pwFileEdit.setText(fname)
 
-class EnterPinDialog(QtGui.QDialog, Ui_EnterPinDialog):
 
-	def __init__(self):
-		QtGui.QDialog.__init__(self)
+class AddGroupDialog(QDialog, Ui_AddGroupDialog):
+
+	def __init__(self, groups):
+		super(AddGroupDialog, self).__init__()
+		self.setupUi(self)
+		self.newGroupEdit.textChanged.connect(self.validate)
+		self.groups = groups
+
+		# disabled for empty string
+		button = self.buttonBox.button(QDialogButtonBox.Ok)
+		button.setEnabled(False)
+
+	def newGroupName(self):
+		return encoding.normalize_nfc(self.newGroupEdit.text())
+
+	def validate(self):
+		"""
+		Validates input if name is not empty and is different from
+		existing group names.
+		"""
+		valid = True
+		text = self.newGroupName()
+		if text == u'':
+			valid = False
+
+		if text in self.groups:
+			self.settings.mlogger.log('Group "%s" already exists. Cannot have '
+				'duplicate group names. Try a different name.' % (text),
+				logging.DEBUG, "Arguments")
+			valid = False
+
+		button = self.buttonBox.button(QDialogButtonBox.Ok)
+		button.setEnabled(valid)
+
+
+class AddPasswordDialog(QDialog, Ui_AddPasswordDialog):
+
+	def __init__(self, trezor):
+		super(AddPasswordDialog, self).__init__()
+		self.setupUi(self)
+		self.pwEdit1.textChanged.connect(self.validatePw)
+		self.pwEdit2.textChanged.connect(self.validatePw)
+		self.showHideButton.clicked.connect(self.switchPwVisible)
+		self.generatePasswordButton.clicked.connect(self.generatePassword)
+		self.trezor = trezor
+
+	def key(self):
+		print('zzz key "%s" %s' % (encoding.normalize_nfc(self.keyEdit.text()), type(encoding.normalize_nfc(self.keyEdit.text()))))
+		return encoding.normalize_nfc(self.keyEdit.text())
+
+	def pw1(self):
+		print('zzz pw1 "%s" %s' % (encoding.normalize_nfc(self.pwEdit1.text()), type(encoding.normalize_nfc(self.pwEdit1.text()))))
+		print('zzz ty %s %s' % (self.pwEdit1.text(), type(self.pwEdit1.text())))
+		return encoding.normalize_nfc(self.pwEdit1.text())
+
+	def pw2(self):
+		return encoding.normalize_nfc(self.pwEdit2.text())
+
+	def comments(self):
+		doc = self.commentsEdit.document().toPlainText()
+		print('zzz doc %s.' % doc)
+		if doc is None:
+			doc = u''
+		else:
+			doc = encoding.normalize_nfc(doc)
+		print('zzz doc %s.' % doc)
+		return doc
+
+	def validatePw(self):
+		same = self.pw1() == self.pw2()
+		button = self.buttonBox.button(QDialogButtonBox.Ok)
+		button.setEnabled(same)
+
+	def switchPwVisible(self):
+		pwMode = self.pwEdit1.echoMode()
+		if pwMode == QLineEdit.Password:
+			newMode = QLineEdit.Normal
+		else:
+			newMode = QLineEdit.Password
+
+		self.pwEdit1.setEchoMode(newMode)
+		self.pwEdit2.setEchoMode(newMode)
+
+	def generatePassword(self):
+		trezor_entropy = self.trezor.get_entropy(32)
+		urandom_entropy = os.urandom(32)
+		passwdBytes = hashlib.sha256(trezor_entropy + urandom_entropy).digest()
+		# base85 encoding not yet implemented in Python 2.7, (requires Python 3+)
+		# so we use base64 encoding
+		# remove the base64 buffer char =, remove easily confused chars 0 and O, as well as I and l
+		passwdB64bytes = base64.urlsafe_b64encode(passwdBytes)
+		passwdB64bytes.replace(b'=', '')
+		passwdB64bytes.replace(b'0', '')
+		passwdB64bytes.replace(b'O', '')
+		passwdB64bytes.replace(b'I', '')
+		passwdB64bytes.replace(b'l', '')
+		# print "bin =", passwdBin, ", base =", passwdB64, " binlen =", len(passwdBin), "baselen =", len(passwdB64)
+		# instead of setting the values, we concatenate them to the existing values
+		# This way, by clicking the "Generate password" button one can create an arbitrary long random password.
+		self.pwEdit1.setText(self.pw1() + encoding.normalize_nfc(passwdB64bytes))
+		self.pwEdit2.setText(self.pw2() + encoding.normalize_nfc(passwdB64bytes))
+
+
+class MainWindow(QMainWindow, Ui_MainWindow):
+	"""
+	Main window for the application with groups and password lists
+	"""
+
+	KEY_IDX = 0  # column where key is shown in password table
+	PASSWORD_IDX = 1  # column where password is shown in password table
+	COMMENTS_IDX = 2  # column where comments is shown in password table
+	NO_OF_PASSWDTABLE_COLUMNS = 3  # 3 columns: key + value/passwd/secret + comments
+	CACHE_IDX = 0  # column of QWidgetItem in whose data we cache decrypted passwords+comments
+
+	def __init__(self, pwMap, settings, dbFilename):
+		"""
+		@param pwMap: a PasswordMap instance with encrypted passwords
+		@param dbFilename: file name for saving pwMap
+		"""
+		super(MainWindow, self).__init__()
 		self.setupUi(self)
 
-		self.pb1.clicked.connect(self.pinpadPressed)
-		self.pb2.clicked.connect(self.pinpadPressed)
-		self.pb3.clicked.connect(self.pinpadPressed)
-		self.pb4.clicked.connect(self.pinpadPressed)
-		self.pb5.clicked.connect(self.pinpadPressed)
-		self.pb6.clicked.connect(self.pinpadPressed)
-		self.pb7.clicked.connect(self.pinpadPressed)
-		self.pb8.clicked.connect(self.pinpadPressed)
-		self.pb9.clicked.connect(self.pinpadPressed)
+		self.logger = settings.logger
+		self.settings = settings
+		self.pwMap = pwMap
+		self.selectedGroup = None
+		self.modified = False  # modified flag for "Save?" question on exit
+		self.dbFilename = dbFilename
 
-	def pin(self):
-		return self.pinEdit.text()
+		self.groupsModel = QStandardItemModel(parent=self)
+		self.groupsModel.setHorizontalHeaderLabels([u"Password group"])
+		self.groupsFilter = QSortFilterProxyModel(parent=self)
+		self.groupsFilter.setSourceModel(self.groupsModel)
 
-	def pinpadPressed(self):
-		sender = self.sender()
-		objName = sender.objectName()
-		digit = objName[-1]
-		self.pinEdit.setText(self.pinEdit.text() + digit)
+		self.groupsTree.setModel(self.groupsFilter)
+		self.groupsTree.setContextMenuPolicy(Qt.CustomContextMenu)
+		self.groupsTree.customContextMenuRequested.connect(self.showGroupsContextMenu)
+		self.groupsTree.clicked.connect(self.loadPasswordsBySelection)
+		self.groupsTree.selectionModel().selectionChanged.connect(self.loadPasswordsBySelection)
+		self.groupsTree.setSortingEnabled(True)
 
-class TrezorChooserDialog(QtGui.QDialog, Ui_TrezorChooserDialog):
+		self.passwordTable.setContextMenuPolicy(Qt.CustomContextMenu)
+		self.passwordTable.customContextMenuRequested.connect(self.showPasswdContextMenu)
+		self.passwordTable.setSelectionBehavior(QAbstractItemView.SelectRows)
+		self.passwordTable.setSelectionMode(QAbstractItemView.SingleSelection)
 
-	def __init__(self, deviceMap):
+		shortcut = QShortcut(QKeySequence(u"Ctrl+C"), self.passwordTable, self.copyPasswordFromSelection)
+		shortcut.setContext(Qt.WidgetShortcut)
+
+		self.actionQuit.triggered.connect(self.close)
+		self.actionQuit.setShortcut(QKeySequence(u"Ctrl+Q"))
+		self.actionExport.triggered.connect(self.exportCsv)
+		self.actionImport.triggered.connect(self.importCsv)
+		self.actionBackup.triggered.connect(self.saveBackup)
+		self.actionAbout.triggered.connect(self.printAbout)
+		self.actionSave.triggered.connect(self.saveDatabase)
+		self.actionSave.setShortcut(QKeySequence(u"Ctrl+S"))
+
+		headerKey = QTableWidgetItem(u"Key")
+		headerValue = QTableWidgetItem(u"Password/Value")
+		headerComments = QTableWidgetItem(u"Comments")
+		self.passwordTable.setColumnCount(self.NO_OF_PASSWDTABLE_COLUMNS)
+		self.passwordTable.setHorizontalHeaderItem(self.KEY_IDX, headerKey)
+		self.passwordTable.setHorizontalHeaderItem(self.PASSWORD_IDX, headerValue)
+		self.passwordTable.setHorizontalHeaderItem(self.COMMENTS_IDX, headerComments)
+
+		self.passwordTable.resizeRowsToContents()
+		self.passwordTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+
+		self.searchEdit.textChanged.connect(self.filterGroups)
+
+		if pwMap is not None:
+			self.setPwMap(pwMap)
+
+		self.clipboard = QApplication.clipboard()
+
+		self.timer = QTimer(parent=self)
+		self.timer.timeout.connect(self.clearClipboard)
+
+	def setPwMap(self, pwMap):
+		""" if not done in __init__ pwMap can be supplied later """
+		self.pwMap = pwMap
+		groupNames = self.pwMap.groups.keys()
+		for groupName in groupNames:
+			item = QStandardItem(groupName)
+			self.groupsModel.appendRow(item)
+		self.groupsTree.sortByColumn(0, Qt.AscendingOrder)
+
+	def setModified(self, modified):
 		"""
-		Create dialog and fill it with labels from deviceMap
-
-		@param deviceMap: dict device string -> device label
+		Sets the modified flag so that user is notified when exiting
+		with unsaved changes.
 		"""
-		QtGui.QDialog.__init__(self)
-		self.setupUi(self)
+		self.modified = modified
+		self.setWindowTitle("TrezorPass" + "*" * int(self.modified))
 
-		for deviceStr, label in deviceMap.items():
-			item = QtGui.QListWidgetItem(label)
-			item.setData(QtCore.Qt.UserRole, QtCore.QVariant(deviceStr))
-			self.trezorList.addItem(item)
-		self.trezorList.setCurrentRow(0)
+	def showGroupsContextMenu(self, point):
+		"""
+		Show context menu for group management.
 
-	def chosenDeviceStr(self):
+		@param point: point in self.groupsTree where click occured
 		"""
-		Returns device string of chosen Trezor
+		self.addGroupMenu = QMenu(self)
+		newGroupAction = QAction('Add group', self)
+		deleteGroupAction = QAction('Delete group', self)
+		self.addGroupMenu.addAction(newGroupAction)
+		self.addGroupMenu.addAction(deleteGroupAction)
+
+		# disable deleting if no point is clicked on
+		proxyIdx = self.groupsTree.indexAt(point)
+		itemIdx = self.groupsFilter.mapToSource(proxyIdx)
+		item = self.groupsModel.itemFromIndex(itemIdx)
+		if item is None:
+			deleteGroupAction.setEnabled(False)
+
+		action = self.addGroupMenu.exec_(self.groupsTree.mapToGlobal(point))
+
+		if action == newGroupAction:
+			self.createGroup()
+		elif action == deleteGroupAction:
+			self.deleteGroup(item)
+
+	def showPasswdContextMenu(self, point):
 		"""
-		itemData = self.trezorList.currentItem().data(QtCore.Qt.UserRole)
-		deviceStr = str(itemData.toString())
-		return deviceStr
+		Show context menu for password management
+
+		@param point: point in self.passwordTable where click occured
+		"""
+		self.passwdMenu = QMenu(self)
+		showPasswordAction = QAction('Show password', self)
+		copyPasswordAction = QAction('Copy password', self)
+		copyPasswordAction.setShortcut(QKeySequence("Ctrl+C"))
+		showCommentsAction = QAction('Show comments', self)
+		copyCommentsAction = QAction('Copy comments', self)
+		newItemAction = QAction('New item', self)
+		deleteItemAction = QAction('Delete item', self)
+		editItemAction = QAction('Edit item', self)
+		self.passwdMenu.addAction(showPasswordAction)
+		self.passwdMenu.addAction(copyPasswordAction)
+		self.passwdMenu.addSeparator()
+		self.passwdMenu.addAction(showCommentsAction)
+		self.passwdMenu.addAction(copyCommentsAction)
+		self.passwdMenu.addSeparator()
+		self.passwdMenu.addAction(newItemAction)
+		self.passwdMenu.addAction(deleteItemAction)
+		self.passwdMenu.addAction(editItemAction)
+
+		# disable creating if no group is selected
+		if self.selectedGroup is None:
+			newItemAction.setEnabled(False)
+
+		# disable deleting if no point is clicked on
+		item = self.passwordTable.itemAt(point.x(), point.y())
+		if item is None:
+			deleteItemAction.setEnabled(False)
+			showPasswordAction.setEnabled(False)
+			copyPasswordAction.setEnabled(False)
+			showCommentsAction.setEnabled(False)
+			copyCommentsAction.setEnabled(False)
+			editItemAction.setEnabled(False)
+
+		action = self.passwdMenu.exec_(self.passwordTable.mapToGlobal(point))
+		if action == newItemAction:
+			self.createPassword()
+		elif action == deleteItemAction:
+			self.deletePassword(item)
+		elif action == editItemAction:
+			self.editPassword(item)
+		elif action == copyPasswordAction:
+			self.copyPasswordFromItem(item)
+		elif action == showPasswordAction:
+			self.showPassword(item)
+		elif action == copyCommentsAction:
+			self.copyCommentsFromItem(item)
+		elif action == showCommentsAction:
+			self.showComments(item)
+
+	def createGroup(self):
+		"""
+		Slot to create a password group.
+		"""
+		dialog = AddGroupDialog(self.pwMap.groups)
+		if not dialog.exec_():
+			return
+
+		groupName = dialog.newGroupName()
+
+		newItem = QStandardItem(groupName)
+		self.groupsModel.appendRow(newItem)
+		self.pwMap.addGroup(groupName)
+
+		# make new item selected to save a few clicks
+		itemIdx = self.groupsModel.indexFromItem(newItem)
+		proxyIdx = self.groupsFilter.mapFromSource(itemIdx)
+		self.groupsTree.selectionModel().select(proxyIdx,
+			QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows)
+		self.groupsTree.sortByColumn(0, Qt.AscendingOrder)
+
+		# Make item's passwords loaded so new key-value entries can be created
+		# right away - better from UX perspective.
+		self.loadPasswords(newItem)
+
+		self.setModified(True)
+
+	def deleteGroup(self, item):
+		msgBox = QMessageBox(text="Are you sure about delete?", parent=self)
+		msgBox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+		res = msgBox.exec_()
+
+		if res != QMessageBox.Yes:
+			return
+
+		name = encoding.normalize_nfc(item.text())
+		self.selectedGroup = None
+		del self.pwMap.groups[name]
+
+		itemIdx = self.groupsModel.indexFromItem(item)
+		self.groupsModel.takeRow(itemIdx.row())
+		self.passwordTable.setRowCount(0)
+		self.groupsTree.clearSelection()
+
+		self.setModified(True)
+
+	def deletePassword(self, item):
+		msgBox = QMessageBox(text="Are you sure about delete?", parent=self)
+		msgBox.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+		res = msgBox.exec_()
+
+		if res != QMessageBox.Yes:
+			return
+
+		row = self.passwordTable.row(item)
+		self.passwordTable.removeRow(row)
+		group = self.pwMap.groups[self.selectedGroup]
+		group.removeEntry(row)
+
+		self.passwordTable.resizeRowsToContents()
+		self.passwordTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+		self.setModified(True)
+
+	def logCache(self, row):
+		item = self.passwordTable.item(row, self.CACHE_IDX)
+		cachedTuple = item.data(Qt.UserRole)
+		if cachedTuple is None:
+			cachedPassword, cachedComments = (None, None)
+		else:
+			cachedPassword, cachedComments = cachedTuple
+		if cachedPassword is not None:
+			cachedPassword = u'***'
+		if cachedComments is not None:
+			cachedComments = cachedComments[0:3] + u'...'
+		self.settings.mlogger.log("Cache holds '%s' and '%s'" %
+			(cachedPassword, cachedComments), logging.DEBUG, "Cache")
+
+	def cachePasswordComments(self, row, password, comments):
+		item = self.passwordTable.item(row, self.CACHE_IDX)
+		item.setData(Qt.UserRole, QVariant((password, comments)))
+
+	def cachedPassword(self, row):
+		"""
+		Retrieve cached password for given row of currently selected group.
+		Returns password as string or None if no password cached.
+		"""
+		item = self.passwordTable.item(row, self.CACHE_IDX)
+		cachedTuple = item.data(Qt.UserRole)
+		if cachedTuple is None:
+			cachedPassword, cachedComments = (None, None)
+		else:
+			cachedPassword, cachedComments = cachedTuple
+		return cachedPassword
+
+	def cachedComments(self, row):
+		"""
+		Retrieve cached comments for given row of currently selected group.
+		Returns comments as string or None if no coments cached.
+		"""
+		item = self.passwordTable.item(row, self.CACHE_IDX)
+		cachedTuple = item.data(Qt.UserRole)
+		if cachedTuple is None:
+			cachedPassword, cachedComments = (None, None)
+		else:
+			cachedPassword, cachedComments = cachedTuple
+		return cachedComments
+
+	def cachedOrDecryptPassword(self, row):
+		"""
+		Try retrieving cached password for item in given row, otherwise
+		decrypt with Trezor.
+		"""
+		cached = self.cachedPassword(row)
+
+		if cached is not None:
+			return cached
+		else:  # decrypt with Trezor
+			group = self.pwMap.groups[self.selectedGroup]
+			pwEntry = group.entry(row)
+			encPwComments = pwEntry[1]
+
+			decryptedPwComments = self.pwMap.decryptPassword(encPwComments, self.selectedGroup)
+			lngth = int(decryptedPwComments[0:4])
+			decryptedPassword = decryptedPwComments[4:4+lngth]
+			decryptedComments = decryptedPwComments[4+lngth:]  # while we are at it, cache the comments too
+			self.cachePasswordComments(row, decryptedPassword, decryptedComments)
+		return decryptedPassword
+
+	def cachedOrDecryptComments(self, row):
+		"""
+		Try retrieving cached comments for item in given row, otherwise
+		decrypt with Trezor.
+		"""
+		cached = self.cachedComments(row)
+
+		if cached is not None:
+			return cached
+		else:  # decrypt with Trezor
+			group = self.pwMap.groups[self.selectedGroup]
+			pwEntry = group.entry(row)
+			encPwComments = pwEntry[1]
+
+			decryptedPwComments = self.pwMap.decryptPassword(encPwComments, self.selectedGroup)
+			lngth = int(decryptedPwComments[0:4])
+			decryptedPassword = decryptedPwComments[4:4+lngth]
+			decryptedComments = decryptedPwComments[4+lngth:]
+			self.cachePasswordComments(row, decryptedPassword, decryptedComments)
+		return decryptedComments
+
+	def showPassword(self, item):
+		# check if this password has been decrypted, use cached version
+		row = self.passwordTable.row(item)
+		self.logCache(row)
+		try:
+			decryptedPassword = self.cachedOrDecryptPassword(row)
+		except CallException:
+			return
+		item = QTableWidgetItem(decryptedPassword)
+
+		self.passwordTable.setItem(row, self.PASSWORD_IDX, item)
+
+	def showComments(self, item):
+		# check if this password has been decrypted, use cached version
+		row = self.passwordTable.row(item)
+		try:
+			decryptedComments = self.cachedOrDecryptComments(row)
+		except CallException:
+			return
+		item = QTableWidgetItem(decryptedComments)
+
+		self.passwordTable.setItem(row, self.COMMENTS_IDX, item)
+
+	def createPassword(self):
+		"""
+		Slot to create key-value password entry.
+		"""
+		if self.selectedGroup is None:
+			return
+		group = self.pwMap.groups[self.selectedGroup]
+		dialog = AddPasswordDialog(self.pwMap.trezor)
+		if not dialog.exec_():
+			return
+
+		plainPw = dialog.pw1()
+		plainComments = dialog.comments()
+		if len(plainPw) + len(plainComments) > basics.MAX_SIZE_OF_PASSWDANDCOMMENTS:
+			self.settings.mlogger.log("Password and/or comments too long. "
+				"Combined they must not be larger than %d." %
+				basics.MAX_SIZE_OF_PASSWDANDCOMMENTS,
+				logging.CRITICAL, "User IO")
+			return
+
+		rowCount = self.passwordTable.rowCount()
+		self.passwordTable.setRowCount(rowCount+1)
+		item = QTableWidgetItem(dialog.key())
+		pwItem = QTableWidgetItem("*****")
+		commentsItem = QTableWidgetItem("*****")
+		self.passwordTable.setItem(rowCount, self.KEY_IDX, item)
+		self.passwordTable.setItem(rowCount, self.PASSWORD_IDX, pwItem)
+		self.passwordTable.setItem(rowCount, self.COMMENTS_IDX, commentsItem)
+
+		plainPwComments = ("%4d" % len(plainPw)) + plainPw + plainComments
+		encPw = self.pwMap.encryptPassword(plainPwComments, self.selectedGroup)
+		bkupPw = self.pwMap.backupKey.encryptPassword(plainPwComments)
+		group.addEntry(dialog.key(), encPw, bkupPw)
+
+		self.cachePasswordComments(rowCount, plainPw, plainComments)
+
+		self.passwordTable.resizeRowsToContents()
+		self.passwordTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+		self.setModified(True)
+
+	def editPassword(self, item):
+		row = self.passwordTable.row(item)
+		group = self.pwMap.groups[self.selectedGroup]
+		try:
+			decrypted = self.cachedOrDecryptPassword(row)
+			decryptedComments = self.cachedOrDecryptComments(row)
+		except CallException:
+			return
+
+		dialog = AddPasswordDialog(self.pwMap.trezor)
+		entry = group.entry(row)
+		dialog.keyEdit.setText(encoding.normalize_nfc(entry[0]))
+		dialog.pwEdit1.setText(encoding.normalize_nfc(decrypted))
+		dialog.pwEdit2.setText(encoding.normalize_nfc(decrypted))
+		doc = QTextDocument(encoding.normalize_nfc(decryptedComments), parent=self)
+		dialog.commentsEdit.setDocument(doc)
+
+		if not dialog.exec_():
+			return
+
+		item = QTableWidgetItem(dialog.key())
+		pwItem = QTableWidgetItem("*****")
+		commentsItem = QTableWidgetItem("*****")
+		self.passwordTable.setItem(row, self.KEY_IDX, item)
+		self.passwordTable.setItem(row, self.PASSWORD_IDX, pwItem)
+		self.passwordTable.setItem(row, self.COMMENTS_IDX, commentsItem)
+
+		plainPw = dialog.pw1()
+		plainComments = dialog.comments()
+		if len(plainPw) + len(plainComments) > basics.MAX_SIZE_OF_PASSWDANDCOMMENTS:
+			self.settings.mlogger.log("Password and/or comments too long. "
+				"Combined they must not be larger than %d." %
+				basics.MAX_SIZE_OF_PASSWDANDCOMMENTS,
+				logging.CRITICAL, "User IO")
+			return
+
+		plainPwComments = ("%4d" % len(plainPw)) + plainPw + plainComments
+
+		encPw = self.pwMap.encryptPassword(plainPwComments, self.selectedGroup)
+		bkupPw = self.pwMap.backupKey.encryptPassword(plainPwComments)
+		group.updateEntry(row, dialog.key(), encPw, bkupPw)
+
+		self.cachePasswordComments(row, plainPw, plainComments)
+
+		self.setModified(True)
+
+	def copyPasswordFromSelection(self):
+		"""
+		Copy selected password to clipboard. Password is decrypted if
+		necessary.
+		"""
+		indexes = self.passwordTable.selectedIndexes()
+		if not indexes:
+			return
+
+		# there will be more indexes as the selection is on a row
+		row = indexes[0].row()
+		item = self.passwordTable.item(row, self.PASSWORD_IDX)
+		self.copyPasswordFromItem(item)
+
+	def copyPasswordFromItem(self, item):
+		row = self.passwordTable.row(item)
+		try:
+			decryptedPassword = self.cachedOrDecryptPassword(row)
+		except CallException:
+			return
+
+		self.clipboard.setText(decryptedPassword)
+		# Do not log contents of clipboard, contains secrets!
+		self.settings.mlogger.log("Copied text to clipboard.", logging.DEBUG,
+			"Clipboard")
+		if basics.CLIPBOARD_TIMEOUT_IN_SEC > 0:
+			self.timer.start(basics.CLIPBOARD_TIMEOUT_IN_SEC*1000)  # cancels previous timer
+
+	def copyCommentsFromItem(self, item):
+		row = self.passwordTable.row(item)
+		try:
+			decryptedComments = self.cachedOrDecryptComments(row)
+		except CallException:
+			return
+
+		self.clipboard.setText(decryptedComments)
+		# Do not log contents of clipboard, contains secrets!
+		self.settings.mlogger.log("Copied text to clipboard.", logging.DEBUG,
+			"Clipboard")
+		if basics.CLIPBOARD_TIMEOUT_IN_SEC > 0:
+			self.timer.start(basics.CLIPBOARD_TIMEOUT_IN_SEC*1000)  # cancels previous timer
+
+	def clearClipboard(self):
+		self.clipboard.clear()
+		self.timer.stop()  # cancels previous timer
+		self.settings.mlogger.log("Clipboard cleared.", logging.DEBUG,
+			"Clipboard")
+
+	def loadPasswords(self, item):
+		"""
+		Slot that should load items for group that has been clicked on.
+		"""
+		self.settings.mlogger.log("Loading password group, clearing table, ...",
+			logging.DEBUG, "User IO")
+		self.passwordTable.clear()  # clears cahce, but also clears the header, the 3 titles
+		headerKey = QTableWidgetItem(u"Key")
+		headerValue = QTableWidgetItem(u"Password/Value")
+		headerComments = QTableWidgetItem(u"Comments")
+		self.passwordTable.setColumnCount(self.NO_OF_PASSWDTABLE_COLUMNS)
+		self.passwordTable.setHorizontalHeaderItem(self.KEY_IDX, headerKey)
+		self.passwordTable.setHorizontalHeaderItem(self.PASSWORD_IDX, headerValue)
+		self.passwordTable.setHorizontalHeaderItem(self.COMMENTS_IDX, headerComments)
+
+		name = encoding.normalize_nfc(item.text())
+		self.selectedGroup = name
+		group = self.pwMap.groups[name]
+		self.passwordTable.setRowCount(len(group.entries))
+
+		i = 0
+		for key, encValue, bkupValue in group.entries:
+			item = QTableWidgetItem(key)
+			pwItem = QTableWidgetItem("*****")
+			commentsItem = QTableWidgetItem("*****")
+			self.passwordTable.setItem(i, self.KEY_IDX, item)
+			self.passwordTable.setItem(i, self.PASSWORD_IDX, pwItem)
+			self.passwordTable.setItem(i, self.COMMENTS_IDX, commentsItem)
+			i = i+1
+
+		self.passwordTable.resizeRowsToContents()
+		self.passwordTable.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+		self.passwordTable.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+
+	def loadPasswordsBySelection(self):
+		proxyIdx = self.groupsTree.currentIndex()
+		itemIdx = self.groupsFilter.mapToSource(proxyIdx)
+		selectedItem = self.groupsModel.itemFromIndex(itemIdx)
+
+		if not selectedItem:
+			return
+
+		self.loadPasswords(selectedItem)
+
+	def filterGroups(self, substring):
+		"""
+		Filter groupsTree view to have items containing given substring.
+		"""
+		self.groupsFilter.setFilterFixedString(substring)
+		self.groupsTree.sortByColumn(0, Qt.AscendingOrder)
+
+	def printAbout(self):
+		"""
+		Show window with about and version information.
+		"""
+		msgBox = QMessageBox(QMessageBox.Information, "About",
+			"About <b>TrezorPass</b>: <br><br>TrezorPass is a safe " +
+			"Password Manager application for people owning a Trezor who prefer to " +
+			"keep their passwords local and not on the cloud. All passwords are " +
+			"stored locally in a single file.<br><br>" +
+			"<b>" + basics.NAME + " Version: </b>" + basics.VERSION_STR +
+			" from " + basics.VERSION_DATE_STR +
+			"<br><br><b>Python Version: </b>" + sys.version.replace(" \n", "; ") +
+			"<br><br><b>Qt Version: </b>" + QT_VERSION_STR +
+			"<br><br><b>PyQt Version: </b>" + PYQT_VERSION_STR, parent=self)
+		msgBox.setIconPixmap(QPixmap("icons/TrezorPass.svg"))
+		msgBox.exec_()
+
+	def saveBackup(self):
+		"""
+		First it saves any pending changes to the pwdb database file. Then it uses an operating system call
+		to copy the file appending a timestamp at the end of the file name.
+		"""
+		if self.modified:
+			self.saveDatabase()
+		backupFilename = self.settings.dbFilename + u"." + time.strftime('%Y%m%d%H%M%S')
+		copyfile(self.settings.dbFilename, backupFilename)
+		self.settings.mlogger.log("Backup of the encrypted database file has been created "
+			"and placed into file \"%s\" (%d bytes)." % (backupFilename, os.path.getsize(backupFilename)),
+			logging.INFO, "User IO")
+
+	def importCsv(self):
+		"""
+		Read a properly formated CSV file from disk
+		and add its contents to the current entries.
+
+		Import format in CSV should be : group, key, password, comments
+
+		There is no error checking, so be extra careful.
+
+		Make a backup first.
+
+		Entries from CSV will be *added* to existing pwdb. If this is not desired
+		create an empty pwdb file first.
+
+		GroupNames are unique, so if a groupname exists then
+		key-password-comments tuples are added to the already existing group.
+		If a group name does not exist, a new group is created and the
+		key-password-comments tuples are added to the newly created group.
+
+		Keys are not unique. So key-password-comments are always added.
+		If a key with a given name existed before and the CSV file contains a
+		key with the same name, then the key-password-comments is added and
+		after the import the given group has 2 keys with the same name.
+		Both keys exist then, the old from before the import, and the new one from the import.
+
+		Examples of valid CSV file format: Some example lines
+		First Bank account,login,myloginname,	# no comment
+		foo@gmail.com,2-factor-authentication key,abcdef12345678,seed to regenerate 2FA codes	# with comment
+		foo@gmail.com,recovery phrase,"passwd with 2 commas , ,",	# with comma
+		foo@gmail.com,large multi-line comments,,"first line, some comma,
+		second line"
+		"""
+		if self.modified:
+			self.saveDatabase()
+		copyfile(self.settings.dbFilename, self.settings.dbFilename + ".beforeCsvImport.backup")
+		self.settings.mlogger.log("WARNING: You are about to import entries from a "
+			"CSV file into your current password-database file. For safety "
+			"reasons please make a backup copy now.", logging.NOTSET,
+			"CSV import")
+		dialog = QFileDialog(self, "Select import CSV file",
+			"", "CVS files (*.csv)")
+		dialog.setAcceptMode(QFileDialog.AcceptOpen)
+
+		res = dialog.exec_()
+		if not res:
+			return
+
+		fname = encoding.normalize_nfc(dialog.selectedFiles()[0])
+		with open(fname, "r") as f:
+			csv.register_dialect("escaped", doublequote=False, escapechar='\\')
+			reader = csv.reader(f, dialect="escaped")
+			for csvEntry in reader:
+				self.settings.mlogger.log("CSV Entry: len=%d 0=%s" % (len(csvEntry), csvEntry[0]),
+					logging.DEBUG, "CSV import")
+				self.settings.mlogger.log("CSV Entry: 0=%s, 1=%s, 2=%s, 3=%s" %
+					(csvEntry[0], csvEntry[1], csvEntry[2], csvEntry[3]), logging.DEBUG,
+					"CSV import")
+				groupName, key, plainPw, plainComments = csvEntry[0], csvEntry[1], csvEntry[2], csvEntry[3]
+				groupNames = self.pwMap.groups.keys()
+				if groupName not in groupNames:  # groups are unique
+					self.pwMap.addGroup(groupName)
+					item = QStandardItem(groupName)
+					self.groupsModel.appendRow(item)
+
+				if len(plainPw) + len(plainComments) > basics.MAX_SIZE_OF_PASSWDANDCOMMENTS:
+					self.settings.mlogger.log("Password and/or comments too long. "
+						"Combined they must not be larger than %d." % basics.MAX_SIZE_OF_PASSWDANDCOMMENTS, logging.NOTSET,
+						"CSV import")
+					return
+				group = self.pwMap.groups[groupName]
+				plainPwComments = ("%4d" % len(plainPw)) + plainPw + plainComments
+				encPw = self.pwMap.encryptPassword(plainPwComments, groupName)
+				bkupPw = self.pwMap.backupKey.encryptPassword(plainPwComments)
+				group.addEntry(key, encPw, bkupPw)  # keys are not unique, multiple items with same key are allowed
+			self.groupsTree.sortByColumn(0, Qt.AscendingOrder)
+			self.setModified(True)
+
+		self.settings.mlogger.log("Trezorpass has finished importing CSV file "
+			"from \"%s\" into \"%s\"." % (fname, self.settings.dbFilename), logging.INFO,
+			"CSV import")
+
+	def exportCsv(self):
+		"""
+		Uses backup key encrypted by Trezor to decrypt all passwords
+		at once and export them into a single paintext CSV file.
+
+		Export format is CSV: group, key, password, comments
+		"""
+		self.settings.mlogger.log("WARNING: During backup/export all passwords will be "
+			"written in plaintext to disk. If possible you should consider performing this "
+			"operation on an offline or air-gapped computer. Be aware of the risks.",
+			logging.NOTSET,	"CSV export")
+		dialog = QFileDialog(self, "Select backup export file",
+			"", "CVS files (*.csv)")
+		dialog.setAcceptMode(QFileDialog.AcceptSave)
+
+		res = dialog.exec_()
+		if not res:
+			return
+
+		fname = encoding.normalize_nfc(dialog.selectedFiles()[0])
+		backupKey = self.pwMap.backupKey
+		try:
+			privateKey = backupKey.unwrapPrivateKey()
+		except CallException:
+			return
+
+		with open(fname, "w") as f:
+			csv.register_dialect("escaped", doublequote=False, escapechar='\\')
+			writer = csv.writer(f, dialect="escaped")
+			sortedGroupNames = sorted(self.pwMap.groups.keys())
+			for groupName in sortedGroupNames:
+				group = self.pwMap.groups[groupName]
+				for entry in group.entries:
+					key, _, bkupPw = entry
+					decryptedPwComments = backupKey.decryptPassword(bkupPw, privateKey)
+					lngth = int(decryptedPwComments[0:4])
+					password = decryptedPwComments[4:4+lngth]
+					comments = decryptedPwComments[4+lngth:]
+					csvEntry = (groupName, key, password, comments)
+					writer.writerow(csvEntry)
+
+		self.settings.mlogger.log("Trezorpass has finished exporting CSV file "
+			"from \"%s\" to \"%s\"." % (self.settings.dbFilename, fname), logging.INFO,
+			"CSV export")
+
+	def saveDatabase(self):
+		"""
+		Save main database file.
+		"""
+		self.pwMap.save(self.dbFilename)
+		self.setModified(False)
+
+	def closeEvent(self, event):
+		if self.modified:
+			msgBox = QMessageBox(text="Password database is modified. Save on exit?", parent=self)
+			msgBox.setStandardButtons(QMessageBox.Yes |
+				QMessageBox.No | QMessageBox.Cancel)
+			reply = msgBox.exec_()
+
+			if not reply or reply == QMessageBox.Cancel:
+				event.ignore()
+				return
+			elif reply == QMessageBox.Yes:
+				self.saveDatabase()
+
+		event.accept()

--- a/encoding.py
+++ b/encoding.py
@@ -1,44 +1,160 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import os
+import os.path
+import random
 import struct
+import unicodedata
 
-from PyQt4 import QtCore
+"""
+This is generic code that should work untouched accross all applications.
+This code implements generic encoding functions.
 
-def q2s(s):
-	"""Convert QString to UTF-8 string object"""
-	return str(s.toUtf8())
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
 
-def s2q(s):
-	"""Convert UTF-8 encoded string to QString"""
-	return QtCore.QString.fromUtf8(s)
 
-class Magic(object):
+def unpack(fmt, s):
+	# 	u = lambda fmt, s: struct.unpack(fmt, s)[0]
+	return(struct.unpack(fmt, s)[0])
+
+
+def pack(fmt, s):
+	# 	p = lambda fmt, s: struct.pack(fmt, s)[0]
+	return(struct.pack(fmt, s))
+
+
+def normalize_nfc(txt):
 	"""
-	Few magic constant definitions so that we know which nodes to search
-	for keys.
+	Utility function to bridge Py2 and Py3 incompatibilities.
+	Convert to NFC unicode.
+	Takes string-equivalent or bytes-equivalent and
+	returns str-equivalent in NFC unicode format.
+	Py2: str (aslias bytes), unicode
+	Py3: bytes, str (in unicode format)
+	Py2-vs-Py3:
 	"""
-	u = lambda fmt, s: struct.unpack(fmt, s)[0]
-	headerStr = "TZPW"
-	hdr = u("!I", headerStr)
-	
-	unlockNode = [hdr, u("!I", "ULCK")] # for unlocking wrapped AES-CBC key
-	groupNode  = [hdr, u("!I", "GRUP")] # for generating keys for individual password groups
-	#the unlock and backup key is written in this weird way to fit display nicely
-	unlockKey = "Decrypt master  key?" # string to derive wrapping key from
-	
-	backupNode = [hdr, u("!I", "BKUP")] # for unlocking wrapped backup private RSA key
-	backupKey = "Decrypt backup  key?" # string to derive backup wrapping key from
-	
+	if sys.version_info[0] < 3:  # Py2-vs-Py3: 
+		if isinstance(txt, unicode):
+			return unicodedata.normalize('NFC', txt)
+		if isinstance(txt, str):
+			return unicodedata.normalize('NFC', txt.decode('utf-8'))
+	else:
+		if isinstance(txt, bytes):
+			return unicodedata.normalize('NFC', txt.decode('utf-8'))
+		if isinstance(txt, str):
+			return unicodedata.normalize('NFC', txt)
+
+
+def tobytes(txt):
+	"""
+	Utility function to bridge Py2 and Py3 incompatibilities.
+	Convert to bytes.
+	Takes string-equivalent or bytes-equivalent and returns bytesequivalent.
+	Py2: str (aslias bytes), unicode
+	Py3: bytes, str (in unicode format)
+	Py2-vs-Py3:
+	"""
+	if sys.version_info[0] < 3:  # Py2-vs-Py3:
+		if isinstance(txt, unicode):
+			return txt.encode('utf-8')
+		if isinstance(txt, str):  # == bytes
+			return txt
+	else:
+		if isinstance(txt, bytes):
+			return txt
+		if isinstance(txt, str):
+			return txt.encode('utf-8')
+
+
 class Padding(object):
 	"""
 	PKCS#7 Padding for block cipher having 16-byte blocks
 	"""
-	
+
 	def __init__(self, blocksize):
 		self.blocksize = blocksize
-	
+
 	def pad(self, s):
+		"""
+		In Python 2 input s is a string, a char list.
+		Python 2 returns a string.
+		In Python 3 input s is bytes.
+		Python 3 returns bytes.
+		"""
 		BS = self.blocksize
-		return s + (BS - len(s) % BS) * chr(BS - len(s) % BS)
-	
+		if sys.version_info[0] > 2:  # Py2-vs-Py3:
+			return s + (BS - len(s) % BS) * bytes([BS - len(s) % BS])
+		else:
+			return s + (BS - len(s) % BS) * chr(BS - len(s) % BS)
+
 	def unpad(self, s):
-		return s[0:-ord(s[-1])]
-	
+		if sys.version_info[0] > 2:  # Py2-vs-Py3:
+			return s[0:-s[-1]]
+		else:
+			return s[0:-ord(s[-1])]
+
+
+class PaddingHomegrown(object):
+	"""
+	Pad filenames that are already base64 encoded. Must have length of multiple of 4.
+	Base64 always have a length of mod 4, padded with =
+	Examples: YQ==, YWI=, YWJj, YWJjZA==, YWJjZGU=, YWJjZGVm, ...
+	On homegrown padding we remove the = pad, then we pad to a mod 16 length.
+	If length is already mod 16, it will be padded with 16 chars. So in all cases we pad.
+	The last letter always represents how many chars have been padded (A=1, ..., P=16).
+	The last letter is in the alphabet A..P.
+	The padded letters before the last letter are pseudo-random in the a..zA..Z alphabet.
+	"""
+
+	def __init__(self):
+		self.homegrownblocksize = 16
+		self.base64blocksize = 4
+
+	def pad(self, s):
+		"""
+		Input must be a string in valid base64 format.
+		Returns a string.
+		"""
+		# the randomness can be poor, it does not matter,
+		# it is just used for buffer letters in the file name
+		urandom_entropy = os.urandom(64)
+		random.seed(urandom_entropy)
+		# remove the base64 buffer char =
+		t = s.replace(u'=', u'')
+		initlen = len(t)
+		BS = self.homegrownblocksize
+		bufLen = BS - len(t) % BS
+		r = initlen*ord(t[-1])*ord(t[:1])
+		for x in range(0, bufLen-1):
+			# Old version:
+			# this was not convenient,
+			# on various encryptions of the same file, multiple encrypted files
+			# with different names would be created, requiring cleanup by
+			# the user as the mapping from plaintext filename to obfuscated
+			# filename was not deterministic
+			# r = random.randint(0, 51) # old version
+			# New version
+			# deterministic mapping of plaintext filename to obfuscated file name
+			r = (((r+17)*15485863) % 52)
+			if r < 26:
+				c = chr(r+ord('a'))
+			else:
+				c = chr(r+ord('A')-26)
+			t += c
+		t += chr(BS - initlen % BS + ord('A') - 1)
+		return t
+
+	def unpad(self, s):
+		"""
+		Input must be a string in valid base64 format.
+		Returns a string.
+		"""
+		t = s[0:-(ord(s[-1])-ord('A')+1)]
+		BS = self.base64blocksize
+		return t + "=" * ((BS - len(t) % BS) % BS)

--- a/encoding.py
+++ b/encoding.py
@@ -39,7 +39,7 @@ def normalize_nfc(txt):
 	Py3: bytes, str (in unicode format)
 	Py2-vs-Py3:
 	"""
-	if sys.version_info[0] < 3:  # Py2-vs-Py3: 
+	if sys.version_info[0] < 3:  # Py2-vs-Py3:
 		if isinstance(txt, unicode):
 			return unicodedata.normalize('NFC', txt)
 		if isinstance(txt, str):
@@ -158,3 +158,12 @@ class PaddingHomegrown(object):
 		t = s[0:-(ord(s[-1])-ord('A')+1)]
 		BS = self.base64blocksize
 		return t + "=" * ((BS - len(t) % BS) % BS)
+
+
+def escape(str):
+	"""
+	Escape the letter \ as \\ in a string.
+	"""
+	if str is None:
+		return u''
+	return str.replace('\\', '\\\\')

--- a/initialize_dialog.ui
+++ b/initialize_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>378</height>
+    <height>500</height>
    </rect>
   </property>
   <property name="maximumSize">
@@ -25,6 +25,58 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="maximumSize">
+        <size>
+         <width>98</width>
+         <height>128</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap>icons/TrezorPass.svg</pixmap>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QTextBrowser" name="textBrowser">
      <property name="focusPolicy">
       <enum>Qt::NoFocus</enum>
@@ -34,9 +86,9 @@
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;This is initialization step of TrezorPass. You need to choose master passphrase that will be used to unlock passwords encrypted with the device.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;This is initialization step of TrezorPass. You need to choose a master passphrase that will be used to unlock passwords encrypted with the device.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;The passphrase is used to derive keys along with secret seed inside Trezor. If forgotten, there's only bruteforcing left.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt;The passphrase along with secret seed inside Trezor are used to derive the encryption keys. If the master passphrase is forgotten, there's only bruteforcing left.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/main_window.ui
+++ b/main_window.ui
@@ -51,7 +51,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Search</string>
+         <string>Search groups</string>
         </property>
        </widget>
       </item>
@@ -87,6 +87,40 @@
         </property>
        </spacer>
       </item>
+      <item>
+       <widget class="QLabel" name="logo">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>27</width>
+          <height>36</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="pixmap">
+         <pixmap>icons/TrezorPass.svg</pixmap>
+        </property>
+        <property name="scaledContents">
+         <bool>true</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>
@@ -110,7 +144,28 @@
        <property name="title">
         <string>Groups</string>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
        <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>10</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QTreeView" name="groupsTree">
           <attribute name="headerMinimumSectionSize">
@@ -131,6 +186,21 @@
         <string>Passwords</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>10</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QTableWidget" name="passwordTable">
           <property name="sizePolicy">

--- a/password_map.py
+++ b/password_map.py
@@ -213,17 +213,10 @@ class PasswordMap(object):
 
 			serialized = self.decryptOuter(encrypted, self.outerIv)
 
-			# group = PasswordGroup()#####zzzz
-			# group.addEntry(u'ABC', b'def', b'ghi')
-			# groups = {}
-			# groups[u'kkeeyy'] = group
-			# serialized = pickle.dumps(groups, pickle.HIGHEST_PROTOCOL)
-			# print(group)
-
 			# Py2-vs-Py3: loads in Py2 does only have 1 arg, all 4 args are required for Py3
 			if sys.version_info[0] < 3:  # Py2-vs-Py3:
 				self.groups = pickle.loads(serialized)
-				print('zzz',self.groups.keys()[0], self.groups[self.groups.keys()[0]])##zz delete
+				# example record: print('example',self.groups.keys()[0], self.groups[self.groups.keys()[0]])
 			else:
 				# loads is different in Py3
 				tmpGroups = pickle.loads(serialized, fix_imports=True, encoding='bytes', errors='strict')
@@ -232,8 +225,7 @@ class PasswordMap(object):
 				if len(tmpGroups) > 0 and isinstance(list(tmpGroups.keys())[0], bytes):
 					tmpGroups = processing.migrateUnpickledDataFromPy2ToPy3(tmpGroups, self.settings)
 				self.groups = tmpGroups
-				print('zzz2',list(self.groups.keys())[0], self.groups[list(self.groups.keys())[0]])##zz delete
-
+				# example record: print('example',list(self.groups.keys())[0], self.groups[list(self.groups.keys())[0]])
 
 	def save(self, fname):
 		"""

--- a/password_map.py
+++ b/password_map.py
@@ -1,50 +1,58 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
 import struct
-import cPickle
 import hmac
 import hashlib
+import logging
+import traceback
+import binascii
+try:
+	import cPickle as pickle
+except Exception:
+	import pickle
 
 from Crypto.Cipher import AES
 from Crypto import Random
 
+from trezorlib.client import CallException, PinException
+
 import basics
+from encoding import normalize_nfc, tobytes, Padding
 from backup import Backup
+import processing
 
-from encoding import Magic, Padding
+"""
+On-disk format
+.4 bytes...header b'TZPW'
+.4 bytes...data storage version, network order uint32_t ==> see basics.PWDB_FILEFORMAT_VERSION
+32 bytes...AES-CBC-encrypted wrappedOuterKey
+16 bytes...IV
+.2 bytes...backup private key size (B)
+.B bytes...encrypted backup key
+.4 bytes...size of data following (N)
+.N bytes...AES-CBC encrypted blob containing pickled structure for password map
+32 bytes...HMAC-SHA256 over data with same key as AES-CBC data struct above
+"""
 
-## On-disk format
-#  4 bytes	header "TZPW"
-#  4 bytes	data storage version, network order uint32_t
-# 32 bytes	AES-CBC-encrypted wrappedOuterKey
-# 16 bytes	IV
-#  2 bytes	backup private key size (B)
-#  B bytes	encrypted backup key
-#  4 bytes	size of data following (N)
-#  N bytes	AES-CBC encrypted blob containing pickled structure for password map
-# 32 bytes	HMAC-SHA256 over data with same key as AES-CBC data struct above
-
-BLOCKSIZE = 16
+BLOCKSIZE = 16  # bytes
 MACSIZE = 32
-KEYSIZE = 32
+KEYSIZE = 32  # bytes
 
-# Data storage version, format of PWDB file
-#version 1 stores only the password in the value part of the key-value pair
-#version 2 stores password and comments in the value part of the key-value pair
-#version 2 software opens a version 1 pwdb file and stores it as version 2; version 1 software cannot open a version 2 pwdb file.
-#i.e. v2 is backwards compatible (v2 software can open v1 dbpw file) but not forwards compatible (v1 software cannot open v2 dbpw file).
-PWDBVERSION = basics.PWDB_FILEFORMAT_VERSION
 
 class PasswordGroup(object):
 	"""
 	Holds data for one password group.
-
 	Each entry has three values:
-	- key
-	- symetrically AES-CBC encrypted password unlockable only by Trezor
-	- RSA-encrypted password for creating backup of all password groups
+	1 key
+	2 symetrically AES-CBC encrypted password unlockable only by Trezor
+	3 RSA-encrypted password for creating backup of all password groups
 	"""
 
 	def __init__(self):
-		self.entries = []
+		self.entries = []  # list of tuples
 
 	def addEntry(self, key, encryptedValue, backupValue):
 		"""Add key-value-backup entry"""
@@ -65,30 +73,82 @@ class PasswordGroup(object):
 		"""Return entry with given index"""
 		return self.entries[idx]
 
+	def entrieslist(self):
+		"""Return entries"""
+		return(self.entries)
+
+	def __str__(self):
+		try:
+			ss = u'[\n'
+			for ee in self.entries:
+				ss += '(\t' + normalize_nfc(ee[0]) + '\n\t' + binascii.hexlify(ee[1]) + '\n\t' + binascii.hexlify(ee[2]) + u'\n)'
+			return(ss+u'\n]')
+		except Exception:
+			ss = u'[\n'
+			mydict = self.__dict__
+			for instvarkey in mydict:
+				instvarval = mydict[instvarkey]
+				for ee in instvarval:
+					ss += '(\t' + normalize_nfc(ee[0]) + '\n\t' + normalize_nfc(binascii.hexlify(ee[1])) + '\n\t' + normalize_nfc(binascii.hexlify(ee[2])) + u'\n)'
+			return(ss+u'\n]')
+
+
 class PasswordMap(object):
 	"""Storage of groups of passwords in memory"""
 
-	MAXPADDEDTREZORENCRYPTSIZE = 1024
-	MAXUNPADDEDTREZORENCRYPTSIZE = MAXPADDEDTREZORENCRYPTSIZE - 1
+	MAX_PADDED_TREZOR_ENCRYPT_SIZE = 1024
+	MAX_UNPADDED_TREZOR_ENCRYPT_SIZE = MAX_PADDED_TREZOR_ENCRYPT_SIZE - 1
 
-	def __init__(self, trezor):
+	def __init__(self, trezor, settings):
 		assert trezor is not None
-		self.groups = {}
+		self.groups = {}  # dict with value being a list of triples
 		self.trezor = trezor
-		self.outerKey = None # outer AES-CBC key
+		self.outerKey = None  # outer AES-CBC key
 		self.outerIv = None  # IV for data blob encrypted with outerKey
-		self.backupKey = None
+		self.backupKey = None  # instance of class backup.Backup
 		self.version = None
+		self.settings = settings
+
+		rng = Random.new()
+		self.outerIv = rng.read(BLOCKSIZE)
+		self.outerKey = rng.read(KEYSIZE)
 
 	def addGroup(self, groupName):
 		"""
 		Add group by name as utf-8 encoded string
 		"""
-		groupName = groupName
 		if groupName in self.groups:
 			raise KeyError("Password group already exists")
 
 		self.groups[groupName] = PasswordGroup()
+
+	def loadWithChecks(self, fname):
+		"""
+		Same as load() but with extra checks.
+
+		@throws IOError: if reading file failed
+		"""
+		try:
+			self.load(fname)
+		except PinException:
+			self.settings.mlooger.log("Invalid Trezor PIN entered. Aborting.",
+				logging.CRITICAL, "Trezor IO")
+			sys.exit(8)
+		except CallException:
+			# this is never reached, there is a sys.exit in the Cancel button
+			self.settings.mlooger.log("User requested to quit (Esc, Cancel).",
+				logging.CRITICAL, "Trezor IO")
+			# button cancel on Trezor, so exit
+			sys.exit(6)
+		except IOError as e:
+			self.settings.mlogger.log("IO Error: Could not decrypt password "
+				"database file: %s" % (e), logging.CRITICAL, "Trezor IO")
+			sys.exit(5)
+		except Exception as e:
+			self.settings.mlogger.log("Could not decrypt passwords: %s" % (e),
+				logging.CRITICAL, "Trezor IO")
+			traceback.print_exc()  # prints to stder
+			sys.exit(5)
 
 	def load(self, fname):
 		"""
@@ -97,12 +157,14 @@ class PasswordMap(object):
 
 		@throws IOError: if reading file failed
 		"""
-		with file(fname) as f:
-			header = f.read(len(Magic.headerStr))
-			if header != Magic.headerStr:
+		self.settings.mlogger.log("Trying to load file '%s'." % (fname),
+			logging.DEBUG, "File IO")
+		with open(fname, "rb") as f:
+			header = f.read(len(basics.Magic.headerStr))
+			if header != basics.Magic.headerStr:
 				raise IOError("Bad header in storage file")
 			version = f.read(4)
-			if len(version) != 4 or ( struct.unpack("!I", version)[0] != 1 and struct.unpack("!I", version)[0] != 2 ):
+			if len(version) != 4 or (struct.unpack("!I", version)[0] != 1 and struct.unpack("!I", version)[0] != 2):
 				raise IOError("Unknown version of storage file")
 			self.version = struct.unpack("!I", version)[0]
 
@@ -130,26 +192,48 @@ class PasswordMap(object):
 			ls = f.read(4)
 			if len(ls) != 4:
 				raise IOError("Corrupted disk format - bad data length")
-			l = struct.unpack("!I", ls)[0]
+			ll = struct.unpack("!I", ls)[0]
 
-			encrypted = f.read(l)
-			if len(encrypted) != l:
+			encrypted = f.read(ll)
+			if len(encrypted) != ll:
 				raise IOError("Corrupted disk format - not enough data bytes")
 
 			hmacDigest = f.read(MACSIZE)
 			if len(hmacDigest) != MACSIZE:
 				raise IOError("Corrupted disk format - HMAC not complete")
 
-			#time-invariant HMAC comparison that also works with python 2.6
+			# time-invariant HMAC comparison that also works with python 2.6
 			newHmacDigest = hmac.new(self.outerKey, encrypted, hashlib.sha256).digest()
 			hmacCompare = 0
 			for (ch1, ch2) in zip(hmacDigest, newHmacDigest):
 				hmacCompare |= int(ch1 != ch2)
 			if hmacCompare != 0:
-				raise IOError("Corrupted disk format - HMAC does not match or bad passphrase")
+				raise IOError("Corrupted disk format - HMAC does not match "
+					"or bad passphrase. Try with a different passphrase.")
 
 			serialized = self.decryptOuter(encrypted, self.outerIv)
-			self.groups = cPickle.loads(serialized)
+
+			# group = PasswordGroup()#####zzzz
+			# group.addEntry(u'ABC', b'def', b'ghi')
+			# groups = {}
+			# groups[u'kkeeyy'] = group
+			# serialized = pickle.dumps(groups, pickle.HIGHEST_PROTOCOL)
+			# print(group)
+
+			# Py2-vs-Py3: loads in Py2 does only have 1 arg, all 4 args are required for Py3
+			if sys.version_info[0] < 3:  # Py2-vs-Py3:
+				self.groups = pickle.loads(serialized)
+				print('zzz',self.groups.keys()[0], self.groups[self.groups.keys()[0]])##zz delete
+			else:
+				# loads is different in Py3
+				tmpGroups = pickle.loads(serialized, fix_imports=True, encoding='bytes', errors='strict')
+				# on the first time we open a pwdb file written in Py2 with Py3
+				# we need to migrate the data to adjust to str vs bytes problem
+				if len(tmpGroups) > 0 and isinstance(list(tmpGroups.keys())[0], bytes):
+					tmpGroups = processing.migrateUnpickledDataFromPy2ToPy3(tmpGroups, self.settings)
+				self.groups = tmpGroups
+				print('zzz2',list(self.groups.keys())[0], self.groups[list(self.groups.keys())[0]])##zz delete
+
 
 	def save(self, fname):
 		"""
@@ -163,13 +247,13 @@ class PasswordMap(object):
 		self.outerIv = rnd.read(BLOCKSIZE)
 		wrappedKey = self.wrapKey(self.outerKey)
 
-		with file(fname, "wb") as f:
-			version = PWDBVERSION
-			f.write(Magic.headerStr)
+		with open(fname, "wb") as f:
+			version = basics.PWDB_FILEFORMAT_VERSION
+			f.write(basics.Magic.headerStr)
 			f.write(struct.pack("!I", version))
 			f.write(wrappedKey)
 			f.write(self.outerIv)
-			serialized = cPickle.dumps(self.groups, cPickle.HIGHEST_PROTOCOL)
+			serialized = pickle.dumps(self.groups, pickle.HIGHEST_PROTOCOL)
 			encrypted = self.encryptOuter(serialized, self.outerIv)
 
 			hmacDigest = hmac.new(self.outerKey, encrypted, hashlib.sha256).digest()
@@ -177,8 +261,8 @@ class PasswordMap(object):
 			lb = struct.pack("!H", len(serializedBackup))
 			f.write(lb)
 			f.write(serializedBackup)
-			l = struct.pack("!I", len(encrypted))
-			f.write(l)
+			ll = struct.pack("!I", len(encrypted))
+			f.write(ll)
 			f.write(encrypted)
 			f.write(hmacDigest)
 
@@ -215,14 +299,18 @@ class PasswordMap(object):
 		"""
 		Decrypt wrapped outer key using Trezor.
 		"""
-		ret = self.trezor.decrypt_keyvalue(Magic.unlockNode, Magic.unlockKey, wrappedOuterKey, ask_on_encrypt=False, ask_on_decrypt=True)
+		ret = self.trezor.decrypt_keyvalue(basics.Magic.unlockNode,
+			basics.Magic.unlockKey, wrappedOuterKey,
+			ask_on_encrypt=False, ask_on_decrypt=True)
 		return ret
 
 	def wrapKey(self, keyToWrap):
 		"""
 		Encrypt/wrap a key. Its size must be multiple of 16.
 		"""
-		ret = self.trezor.encrypt_keyvalue(Magic.unlockNode, Magic.unlockKey, keyToWrap, ask_on_encrypt=False, ask_on_decrypt=True)
+		ret = self.trezor.encrypt_keyvalue(basics.Magic.unlockNode,
+			basics.Magic.unlockKey, keyToWrap,
+			ask_on_encrypt=False, ask_on_decrypt=True)
 		return ret
 
 	def encryptPassword(self, password, groupName):
@@ -230,23 +318,31 @@ class PasswordMap(object):
 		Encrypt a password. Does PKCS#5 padding before encryption.
 		Store IV as first block.
 
-		@param groupName key that will be shown to user on Trezor and
+		@param password: text to encrypt (combined password+comments)
+		@type password: string
+		@param groupName: key that will be shown to user on Trezor and
 			used to encrypt the password. A string in utf-8
+		@type groupName: string
+		@returns: bytes
 		"""
 		rnd = Random.new()
 		rndBlock = rnd.read(BLOCKSIZE)
-		ugroup = groupName.decode("utf-8")
+		ugroup = tobytes(groupName)
+		password = tobytes(password)
 		# minimum size of unpadded plaintext as input to trezor.encrypt_keyvalue() is 0    ==> padded that is 16 bytes
 		# maximum size of unpadded plaintext as input to trezor.encrypt_keyvalue() is 1023 ==> padded that is 1024 bytes
 		# plaintext input to trezor.encrypt_keyvalue() must be a multiple of 16
 		# trezor.encrypt_keyvalue() throws error on anythin larger than 1024
 		# In order to handle passwords+comments larger than 1023 we junk the passwords+comments
-		encrypted = ""
+		encrypted = b""
 		first = True
-		splits=[password[x:x+self.MAXUNPADDEDTREZORENCRYPTSIZE] for x in range(0,len(password),self.MAXUNPADDEDTREZORENCRYPTSIZE)]
+		splits = [password[x:x+self.MAX_UNPADDED_TREZOR_ENCRYPT_SIZE]
+			for x in range(0, len(password), self.MAX_UNPADDED_TREZOR_ENCRYPT_SIZE)]
 		for junk in splits:
 			padded = Padding(BLOCKSIZE).pad(junk)
-			encrypted += self.trezor.encrypt_keyvalue(Magic.groupNode, ugroup, padded, ask_on_encrypt=False, ask_on_decrypt=first, iv=rndBlock)
+			encrypted += self.trezor.encrypt_keyvalue(basics.Magic.groupNode,
+				ugroup, padded,
+				ask_on_encrypt=False, ask_on_decrypt=first, iv=rndBlock)
 			first = False
 		ret = rndBlock + encrypted
 		# print "Trezor encryption: plain-size =", len(password), ", encrypted-size =", len(encrypted)
@@ -258,15 +354,19 @@ class PasswordMap(object):
 
 		@param groupName key that will be shown to user on Trezor and
 			was used to encrypt the password. A string in utf-8.
+		@returns: string in unicode
 		"""
-		ugroup = groupName.decode("utf-8")
+		ugroup = tobytes(groupName)
 		iv, encryptedPassword = encryptedPassword[:BLOCKSIZE], encryptedPassword[BLOCKSIZE:]
 		# we junk the input, decrypt and reassemble the plaintext
-		password = ""
+		passwordBytes = b""
 		first = True
-		splits=[encryptedPassword[x:x+self.MAXPADDEDTREZORENCRYPTSIZE] for x in range(0,len(encryptedPassword),self.MAXPADDEDTREZORENCRYPTSIZE)]
+		splits = [encryptedPassword[x:x+self.MAX_PADDED_TREZOR_ENCRYPT_SIZE]
+			for x in range(0, len(encryptedPassword), self.MAX_PADDED_TREZOR_ENCRYPT_SIZE)]
 		for junk in splits:
-			plain = self.trezor.decrypt_keyvalue(Magic.groupNode, ugroup, junk, ask_on_encrypt=False, ask_on_decrypt=first, iv=iv)
+			plain = self.trezor.decrypt_keyvalue(basics.Magic.groupNode,
+				ugroup, junk,
+				ask_on_encrypt=False, ask_on_decrypt=first, iv=iv)
 			first = False
-			password += Padding(BLOCKSIZE).unpad(plain)
-		return password
+			passwordBytes += Padding(BLOCKSIZE).unpad(plain)
+		return normalize_nfc(passwordBytes)

--- a/processing.py
+++ b/processing.py
@@ -90,40 +90,44 @@ def migrateUnpickledDataFromPy2ToPy3(groupsDict, settings):
 	settings.mlogger.log("Trying to migrate TrezorPass database \"%s\" "
 		"from Python 2 ro Python3." % settings.dbFilename, logging.DEBUG,
 		"TrezorPass database")
-	print('zzz3',groupsDict)
+	#### this function requires cleanup and documentation! zzz
+	# print(groupsDict)
 	groupsNew = {}  # PasswordGroup()
 	ii = 0
 	for groupName in groupsDict:
 		ii += 1
-		print('groupName %s' % (groupName))
+		#print('groupName %s' % (groupName))
 		pwGroup = groupsDict[groupName]
-		print('\n pwGroup %s %s' % (pwGroup, type(pwGroup)))
-		print('\n groupName %s %s' % (groupName, type(groupName)))  # Py2: str, Py3: bytes
+		#print('\n pwGroup %s %s' % (pwGroup, type(pwGroup)))
+		#print('\n groupName %s %s' % (groupName, type(groupName)))  # Py2: str, Py3: bytes
 		groupsNew[normalize_nfc(groupName)] = PasswordGroup()
-		print('groupsNew')
-		pprint(groupsNew)
-		pprint(dict(groupsNew))
-		print('groupNew')
-		pprint(groupsNew[normalize_nfc(groupName)])
-		pprint(vars(groupsNew[normalize_nfc(groupName)]))
-		print('pwGroup')
-		pprint(vars(pwGroup))
+		#print('groupsNew')
+		#pprint(groupsNew)
+		#pprint(dict(groupsNew))
+		#print('groupNew')
+		#pprint(groupsNew[normalize_nfc(groupName)])
+		#pprint(vars(groupsNew[normalize_nfc(groupName)]))
+		#print('pwGroup')
+		#pprint(vars(pwGroup))
 
 		mydict = pwGroup.__dict__
-		
-		print('\n mydict %s %s\n' % (mydict, type(mydict)))
+
+		#print('\n mydict %s %s\n' % (mydict, type(mydict)))
 		for instvarkey in mydict:
-			print('\n instvarkey %s %s\n' % (instvarkey, type(instvarkey)))  # bytes
+			#print('\n instvarkey %s %s\n' % (instvarkey, type(instvarkey)))  # bytes
 			instvarval = mydict[instvarkey]
-			print('\n instvarval %s %s\n' % (instvarval, type(instvarval)))  # list
+			#print('\n instvarval %s %s\n' % (instvarval, type(instvarval)))  # list
 			for triple in instvarval:
-				print('\n triple %s %s\n' % (triple, type(triple)))  # tuple
+				#print('\n triple %s %s\n' % (triple, type(triple)))  # tuple
 				key, encPw, bkupPw = triple
 				groupsNew[normalize_nfc(groupName)].addEntry(normalize_nfc(key), encPw, bkupPw)
-				print('groupNew')
-				pprint(groupsNew[normalize_nfc(groupName)])
-				pprint(vars(groupsNew[normalize_nfc(groupName)]))
-	print("\n %d groups migrated." % (ii))
+				#print('groupNew')
+				#pprint(groupsNew[normalize_nfc(groupName)])
+				#pprint(vars(groupsNew[normalize_nfc(groupName)]))
+	#print("\n %d groups migrated." % (ii))
+	settings.mlogger.log("%d password groups have been migrated "
+		"from Python 2 to Python3." % (ii), logging.DEBUG,
+		"TrezorPass database")
 
-	#pprint('zzz5',groupsNew)
+	#pprint(groupsNew)
 	return(groupsNew)

--- a/processing.py
+++ b/processing.py
@@ -1,218 +1,129 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import sys
-import struct
 import logging
-import getopt
-import re
-import datetime
-import traceback
-import os.path
+from pprint import pprint
 
-from PyQt4 import QtCore
-from PyQt4 import QtGui
+from dialogs import InitializeDialog
+import backup
+from encoding import normalize_nfc
+from password_map import PasswordGroup
+
+"""
+This file holds the main business logic.
+It should be shared by the GUI mode and the Terminal mode.
+"""
 
 
-from trezorlib.client import CallException, PinException
-
-from encoding import q2s, s2q
-import basics
-
-class Settings(object):
+def initializeStorage(trezor, pwMap, settings):
 	"""
-	Settings for command line options
-	Settings for password database location
+	Initialize new encrypted password file, ask for master passphrase.
+
+	Initialize RSA keypair for backup, encrypt private RSA key using
+	backup passphrase and Trezor's cipher-key-value system.
+
+	Makes sure a session is created on Trezor so that the passphrase
+	will be cached until disconnect.
+
+	@param trezor: Trezor client
+	@param pwMap: PasswordMap where to put encrypted backupKeys
+	@param settings: Settings object to store password database location
 	"""
+	dialog = InitializeDialog()
+	if settings.passphrase() is not None:
+		dialog.setPw1(settings.passphrase())
+		dialog.setPw2(settings.passphrase())
 
-	def __init__(self, logger):
-		self.dbFilename = None
-		self.settings = QtCore.QSettings("ConstructibleUniverse", "TrezorPass")
-		fname = self.settings.value("database/filename")
-		if fname.isValid():
-			self.dbFilename = q2s(fname.toString())
+	if not dialog.exec_():
+		sys.exit(4)
 
-		self.logger = logger
-		self.VArg = False
-		self.HArg = False
-		self.PArg = None
-		self.DArg = False
-		self.FArg = ""
-
-	def printSettings(self):
-		self.logger.debug("self.dbFilename = %s", self.dbFilename)
-		fname = self.settings.value("database/filename")
-		self.logger.debug("QtCore.QSettings = %s", q2s(fname.toString()))
-		self.logger.debug("self.VArg = %s", self.VArg)
-		self.logger.debug("self.HArg = %s", self.HArg)
-		self.logger.debug("self.PArg = %s", self.PArg)
-		self.logger.debug("self.DArg = %s", self.DArg)
-		self.logger.debug("self.FArg = %s", self.FArg)
-
-	def store(self):
-		self.settings.setValue("database/filename", s2q(self.dbFilename))
-
-	def passphrase(self):
-		return self.PArg
+	masterPassphrase = dialog.pw1()
+	trezor.prefillPassphrase(masterPassphrase)
+	backupkey = backup.Backup(trezor)
+	backupkey.generate()
+	pwMap.backupKey = backupkey
+	settings.dbFilename = dialog.pwFile()
+	settings.FArg = dialog.pwFile()
+	settings.store()
 
 
-def usage():
-	print """TrezorPass.py [-v] [-h] [-l <level>] [-p <passphrase>] [[-d] -f <pwdbfile>]
-		-v, --version
-				print the version number
-		-h, --help
-				print short help text
-		-l, --logging
-				set logging level, integer from 1 to 5, 1=full logging, 5=no logging
-		-p, --passphrase
-				master passphrase used for Trezor.
-				It is recommended that you do not use this command line option
-				but rather give the passphrase through a small window interaction.
-		-f, --pwdbfile
-				name of an existing password file to use instead of the default one;
-				must be a valid TrezorPass password file
-		-d, --setdefault
-				set the file provided with `-f` as default, i.e. this will
-				be the password file opened from now on
-
-		All arguments are optional. Usually none needs to be used.
-
-		Examples:
-		# normal operation
-		TrezorPass.py
-
-		# normal operation with verbose logging at Debug level
-		TrezorPass.py -l 1
-
-		# open some old backup password database (once)
-		TrezorPass.py -f trezorpass.backup.170101.pwdb
-
-		# from now on always by default open password database from environment 2
-		TrezorPass.py -d -f trezorpass.env2.pwdb
-		"""
-
-def printVersion():
+def updatePwMapFromV1ToV2(pwMap, settings):
 	"""
-	Show about and version information.
+	Update the pwMap from v1 (only password) to v2 (password and comments).
 	"""
-	print "Version: %s from %s" % (basics.VERSION_STR, basics.VERSION_DATE_STR)
-	print("About TrezorPass: TrezorPass is a safe Password Manager application \n"
-		"for people owning a Trezor who prefer to keep their passwords local \n"
-		"and not on the cloud. All passwords are stored locally in a single file.")
-
-def parseArgs(argv, settings, logger):
+	backupKey = pwMap.backupKey
 	try:
-		opts, args = getopt.getopt(argv,"vhl:p:df:",
-			["version","help","logging=","passphrase=","setdefault","pwdbfile="])
-	except getopt.GetoptError, e:
-		msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Critical, "Wrong arguments", "Error: " + str(e))
-		msgBox.exec_()
-		logger.critical('Wrong arguments. Error: %s.', str(e))
-		sys.exit(2)
-	loglevelused = False
-	for opt, arg in opts:
-		if opt in ("-h","--help"):
-			usage()
-			sys.exit()
-		elif opt in ("-v", "--version"):
-			printVersion()
-			sys.exit()
-		elif opt in ("-l", "--logging"):
-			loglevelarg = arg
-			loglevelused = True
-		elif opt in ("-p", "--passphrase"):
-			settings.PArg = arg
-		elif opt in ("-d", "--setdefault"):
-			settings.DArg = True
-		elif opt in ("-f", "--pwdbfile"):
-			settings.FArg = arg
+		privateKey = backupKey.unwrapPrivateKey()
+	except Exception as e:
+		settings.mlogger.log("Error getting key for doing backup (%s)." % (e),
+			logging.ERROR, "TrezorPass database")
+		return
 
-	if loglevelused:
-		try:
-			loglevel = int(loglevelarg)
-		except Exception, e:
-			reportLogging("Logging level not specified correctly. "
-				"Must be integer between 1 and 5. (%s)" % loglevelarg, logging.CRITICAL,
-				"Wrong arguments", settings, logger)
-			sys.exit(18)
-		if loglevel > 5 or loglevel < 1:
-			reportLogging("Logging level not specified correctly. "
-				"Must be integer between 1 and 5. (%s)" % loglevelarg, logging.CRITICAL,
-				"Wrong arguments", settings, logger)
-			sys.exit(19)
-		basics.DEFAULT_LOG_LEVEL = loglevel * 10 # https://docs.python.org/2/library/logging.html#levels
-		logger.setLevel(basics.DEFAULT_LOG_LEVEL)
-		logger.info('Logging level set to %s (%d).',
-			logging.getLevelName(basics.DEFAULT_LOG_LEVEL), basics.DEFAULT_LOG_LEVEL)
+	for groupName in pwMap.groups.keys():
+		group = pwMap.groups[groupName]
+		for entry in group.entries:
+			key, encryptedPw, bkupPw = entry
+			plainPw = backupKey.decryptPassword(bkupPw, privateKey)
+			plainPwComments = ("%4d" % len(plainPw)) + plainPw
+			encPw = pwMap.encryptPassword(plainPwComments, groupName)
+			bkupPw = pwMap.backupKey.encryptPassword(plainPwComments)
+			idx = group.entries.index(entry)
+			group.updateEntry(idx, key, encPw, bkupPw)
+	pwMap.save(settings.dbFilename)
+	settings.mlogger.log("Trezorpass database \"%s\" successfully "
+		"updated from version 1 to version 2." % settings.dbFilename, logging.NOTSET,
+		"TrezorPass database")
 
-	if len(args) != 0:
-		reportLogging("Incorrect arguments %s found in command line. "
-			"Correct your input." % str(args), logging.ERROR,
-			"Wrong arguments", settings, logger)
-		sys.exit(20)
 
-	if (settings.FArg == "") and settings.DArg:
-		reportLogging("Don't used `-d` without the `-f` argument. Aborting.",
-			logging.ERROR,
-			"Wrong arguments", settings, logger)
-		sys.exit(21)
-
-	if (settings.FArg != "") and not os.path.isfile(settings.FArg):
-		reportLogging("File \"%s\" does not exist, is not a proper file, "
-			"or is a directory. Aborting." % settings.FArg, logging.ERROR,
-			"File IO Error", settings, logger)
-		sys.exit(21)
-	elif (settings.FArg != "") and not os.access(settings.FArg, os.R_OK):
-		reportLogging("File \"%s\" cannot be read. No read permissions. "
-			"Aborting." % settings.FArg, logging.ERROR, "File IO Error",
-			settings, logger)
-		sys.exit(22)
-	elif settings.FArg != "":
-		settings.dbFilename = settings.FArg
-		if settings.DArg:
-			settings.store() # update/store permanently
-	settings.printSettings()
-
-def reportLogging(str, level, title, settings, logger):
+def migrateUnpickledDataFromPy2ToPy3(groupsDict, settings):
 	"""
-	Displays string str depending on scenario:
-	a) on terminal mode: thru logger (except if loglevel == NOTSET)
-	b) thru QMessageBox()
-
-	NOTSET means it will be printed, both terminal and QMessageBox
-
-	@param str: string to report/log
-	@param level: log level from DEBUG to CRITICAL
-	@param title: window title text
+	Takes an instance such as PasswordMap.groups
+	which is a dictionary of PasswordGroup instances.
+	Each PasswordGroup instance an object with entries
+	which are lists of tuples.
+	Only works in Python3, Py3.
 	"""
-	if level == logging.NOTSET:
-		print str # stdout
-		msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Information,
-			title, "%s" % (str))
-		msgBox.exec_()
-	elif level == logging.DEBUG:
-		logger.debug(str)
-		# don't spam the user with too many pop-ups
-		# For debug, instead of a pop-up we write to stdout
-		# do nthing
-	elif level == logging.INFO:
-		logger.info(str)
-		if logger.getEffectiveLevel() <= level:
-			msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Information,
-				title, "Info: %s" % (str))
-			msgBox.exec_()
-	elif level == logging.WARN:
-		logger.warning(str)
-		if logger.getEffectiveLevel() <= level:
-			msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Warning,
-				title, "Warning: %s" % (str))
-			msgBox.exec_()
-	elif level == logging.ERROR:
-		logger.error(str)
-		if logger.getEffectiveLevel() <= level:
-			msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Critical,
-				title, "Error: %s" % (str))
-			msgBox.exec_()
-	elif level == logging.CRITICAL:
-		logger.critical(str)
-		if logger.getEffectiveLevel() <= level:
-			msgBox = QtGui.QMessageBox(QtGui.QMessageBox.Critical,
-				title, "Critical: %s" % (str))
-			msgBox.exec_()
+	if sys.version_info[0] < 3:  # Py2-vs-Py3:
+		raise RuntimeError(u"This code should only have been called with Python 3 or higher.")
+	settings.mlogger.log("Trying to migrate TrezorPass database \"%s\" "
+		"from Python 2 ro Python3." % settings.dbFilename, logging.DEBUG,
+		"TrezorPass database")
+	print('zzz3',groupsDict)
+	groupsNew = {}  # PasswordGroup()
+	ii = 0
+	for groupName in groupsDict:
+		ii += 1
+		print('groupName %s' % (groupName))
+		pwGroup = groupsDict[groupName]
+		print('\n pwGroup %s %s' % (pwGroup, type(pwGroup)))
+		print('\n groupName %s %s' % (groupName, type(groupName)))  # Py2: str, Py3: bytes
+		groupsNew[normalize_nfc(groupName)] = PasswordGroup()
+		print('groupsNew')
+		pprint(groupsNew)
+		pprint(dict(groupsNew))
+		print('groupNew')
+		pprint(groupsNew[normalize_nfc(groupName)])
+		pprint(vars(groupsNew[normalize_nfc(groupName)]))
+		print('pwGroup')
+		pprint(vars(pwGroup))
+
+		mydict = pwGroup.__dict__
+		
+		print('\n mydict %s %s\n' % (mydict, type(mydict)))
+		for instvarkey in mydict:
+			print('\n instvarkey %s %s\n' % (instvarkey, type(instvarkey)))  # bytes
+			instvarval = mydict[instvarkey]
+			print('\n instvarval %s %s\n' % (instvarval, type(instvarval)))  # list
+			for triple in instvarval:
+				print('\n triple %s %s\n' % (triple, type(triple)))  # tuple
+				key, encPw, bkupPw = triple
+				groupsNew[normalize_nfc(groupName)].addEntry(normalize_nfc(key), encPw, bkupPw)
+				print('groupNew')
+				pprint(groupsNew[normalize_nfc(groupName)])
+				pprint(vars(groupsNew[normalize_nfc(groupName)]))
+	print("\n %d groups migrated." % (ii))
+
+	#pprint('zzz5',groupsNew)
+	return(groupsNew)

--- a/processing.py
+++ b/processing.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import sys
 import logging
-from pprint import pprint
 
 from dialogs import InitializeDialog
 import backup
@@ -77,57 +76,147 @@ def updatePwMapFromV1ToV2(pwMap, settings):
 		"TrezorPass database")
 
 
-def migrateUnpickledDataFromPy2ToPy3(groupsDict, settings):
+def migrateUnpickledDataFromPy2ToPy3(groupsDictPy2, settings):
 	"""
 	Takes an instance such as PasswordMap.groups
 	which is a dictionary of PasswordGroup instances.
-	Each PasswordGroup instance an object with entries
+	Each PasswordGroup instance is an object with entries
 	which are lists of tuples.
 	Only works in Python3, Py3.
+	Migrates unpickled pwdb data of groups from Py2 to Py3 format.
+	Takes an unpickled pwdb groups object in Py2 and
+	returns an unpickled pwdb groups object in Py3 format.
+
+	This code can be removed once Py2 is no longer supported.
+
+	Case 1:
+	Py2 unpickling a Py2-pickled pwdb file sees the following:
+	groups = {'some groupname': <password_map.PasswordGroup object at 0x0fd06a4abed0>, ...}
+	with password_map.PasswordGroup being seen as:
+	{'entries': [('some username',
+		'$-WA\xaf\x04z\xff\n\x0f\xb1\x1cTo\xd8\xc2\xe6\xab\xd9\x96%\xce\x90\xb6\x82\x8e-\xb62A\x1d\xc5',
+		'"T06\xea\xa5\x83qP\x0f5\xd0~\xc4\x83Fb\x8ei\x08\xb6\xe0\xa0\x91\x88d\x14I\x9c\xae\xbd\x04\xb8T!6\x1d\xb3\xcd\xd2\x08j\xc1\xaf\xce\xdb\xe7\x8cq^\xa1`\x93\xf1\xeb\xd7\xf1X\x80\x80\xdb8Y\xca{\xa5s\x82"Z\x9b}\xba\xaa\x0c>P~\xbd1\xde\xaaM\xed]\x9eq\x13PI\xd1\x1f\x9fRc\xa4\x15\xdd\xd2\xa8\xe3d\xcf\xe3w\xd5\xf5\x04\xbdR\x86\xc9\xb7\x97\xec\xe1@\xa7\x08\xf1\xef)\x93\xa0n\xcb\xaaH2\xb8%\xb8\'\xd8\x06\xd0\xb4*\xe0\xdb}\x91\xa1\xd4J\\+\r\xb8\xe6a\xba\xdf\xa0\xe2\xbe\xeb5\xbf\xdfh\xae\xd9\x83\x93lT\xcc\x07\x95$@\x1c@\x89R\xe9\xf1\xf0+w\x07i~/\x17^\t\xceVuU\x11\x12\x1c\x90*qt\t\x06_q\xa9\x8c\x85\x99\x11\x98v\xe18\xe3\x19\xcf\xaa\x9a7\xa0qk\x00\x8d\xdbh\xf0\x90\x08\xac\x14k?\x1a\xcc>\x92o\xd1\xf6\xfbK&\xc8\x88\x01\x8d\xad<\xeba\xff\xa5\x0eH\xf8r=]\xb4TT\xd1\xa0\xd6P\x98Gl|\xec\xcbpo\x90k:\xf1\x8d\xcf\xe7\xb5S1\xbd\x93\x15\xd2\xb3@G\x1f\x8eIkz\xfd&\x1bb\x0b\xa5\xac\xa7L\r\xf3\x0e\xfb\xd9\xa0\xf6@\xc5\xa9\xd3Dexi;GYk\xdc\xeb\xa8\x11\xca\x0c\x88X\x9e{I\xc1\xeb\xd3\x8e]\x81\xbe\xcd\x10\x1b\xea\x04\xb1h\x88\xe6\x9f\xcfz\x86W_1*MQ\x16\x9c\x9a=\xf3\x96\xb8\x8d\xad\nEI\x14s0\xcbZ\xc6\xda\r\xbb\n\xe0\xdf\xfac\x84\xb4y\xf0\xa63n\xf9H/V\xbe\xd3t\x85\xfe\xcb\xb7L>\x04U\xb0"\xbd\x87n\xc1)P\xeeJ\xbf\xb7\xbb\xe9\xb5)(\xf7D\x89\xe9Z\x97T\xb1x\x19/\xb9\x08\x1f\xd7+?\xeaTg_\xd2\x85\xc6\x86\xd87\t3V\xfeu\x03r\xb7g\xb9\x90\xa5\xa0\xcf=:\xe7\x19\xf9S\xa4\x16\x88\xa1~"\xd9\x05K\x9b2\x1e\x04Q\x8c\xf9\xc1\x02\x865\x8b\xde\xc9\xe2\x1f\xf1\xfc\xf4S\xff\xc8\x8e\x11\xc0\x95\xe8\x0b\xe0\x0e\x16'), ...]}
+	So, for Py2 this works: tuple = pwMap.groups['some groupname'].entries[0]
+	Specifically, group.entries exists as expected.
+	All items like groupname, the 3 items in the tuple are of type 'str'.
+	vars(self.groups[self.groups.keys()[0]]): works
+	dict(self.groups[self.groups.keys()[0]]): fails, TypeError: 'PasswordGroup' object is not iterable
+
+	Case 2:
+	Py3 unpickling a Py2-pickled pwdb file sees the following:
+	groups = {b'some groupname': <password_map.PasswordGroup object at 0x0fd06a4abed0>, ...}
+	with password_map.PasswordGroup being seen as:
+	{b'entries': [(b'some username',
+		b'\xb7\x877\xb3\xf4\xaf\xa0\x91\xec\x7fOlr\x8fn\xf3\xed\x8b\x1a\x15\xc7\xc5\x14\xc7\xeb\xb2[\xb5l\xab\xe9\xc9\x97\x1b\xff\xac\x1a\xd1\xc3\xce\x1bXTH\x89\xef\x00Y',
+		b'_\xc2\x94B\x07]\x13\xc4\xaa)K\xb34`\xf5\xd9\xc0g\xefqX6\xa3\x95T5\\\xa9\x1eX\x19$\x02G\xaf8\x98\'\x05\xcc\xae\xb5^m\x0f\x92\x94\xcfI\xb9\xa1\xd2\xbfe2\x00E\xca\xf5\x84\xea\xcc\xe9\xaf+\xad\x90a\x06\x00Z7^\xe6\xc1EOn\xa5\x10mN\xf6\xdd\x92\x13\xe6[Ba\xe2\xa2iY2\x05\xc6\xc4\x9b\\^\xef"\x19O\xa3\xcd\xe4\xc5\x9eT\x80s\x81\xee\xc2$\x92\xfdQ\x86\xaf\xcf\x16\xb0<\xc3j\'\xf0G\x01\xa9\xcf;\xb1l\xcf\xcd4\xc6\x0cN\xba\xe4pK\xa4y\xf7\x01\xe8+v\x80\xa8<\xf8\x9f\xb4d\xb7\xe0\xb5\xbc^6\xc9J\\\xe3\x91\x9a\xa5\x08)\x0b\x958YI\xb5\xb7(W\xa5\xf8G\x02\x0f\x9c\x8dE\x0c*\\\xc9\x07\xaaW\xe3>\x93\x7f\x87\xe5\xff\xfe\x16G\xcf\x90\xd4\xd6?\xf0\x16\xa4\x93\xce\xd8\x9c\xf1\xff\x81`\xbf"W\xee\xfb\\[\xe5\x13\xd8[R\xec\xd2\xc6Erh\xdf\xdd\xebX\x8f\xf4[\x0e\x9d\xea\xa1\t;\xaf\x81\x8b\xc0\xb4\xa77\xde8v\xe4\x94\xf0\x87(\xa4\x87\x99\x9dCd\x08^\xb8\x84\x83E\x1a[/\xda\xc82,\xb4o\xea\x1cSI_\xb3\xd0t<\xe1\xea\xbb\x9c\n9IOuf\x95A\xec\xa7\xfa2>$\xb4\xea0\xcd\xc3\xa3\x1e\t&\x8cI\xfdqN0\xd1J\xebU>\xf1x\xc4\xb2\x0en\x8c\xaf\\B5b\xc9\xce\x87\xb4\x15\xbe\xe8e0\xe0\xa5@\x01Ib\xc3l#Z\xc7o%\xd9C\xac\xee\x16\xe1\xee\xba\xc3\xbe\x96\xdc\xba\xbc\xc4w\xb1\x7f\x02\x95\xcf(skt/\x84\x0b1\xb7\x14\\\xc6\x9e\xb4c\xcb\xc8\xb8\x8bY\'\x1a\xf6\xa35^\x1f\xba\x9c\x93\x8c\xa15\xbfdZ0\n\x9en{\xc0\xb5\x02>N\xee\xb2c\xc4\xcf\xb6\xc1Ot\xd7\x00\x0c\xb7\xc4x\x1dt\x92\'T*\xedW\xe7s\xed\x95J\x0f\xd8**"\xf4s\x1b\x1fK2\n\xb0\x8f\xb1P\xff\xa0\xe0\xdd\xd6\x94\x94ed\x1d\x07\xd7G\x99B]S\xa2\x8d\xe3\xd1\xa2Q`\xd6\x9b\x83'), ...]}
+	So, for Py3 this leads to an exception: tuple = pwMap.groups['some groupname'].entries[0]
+	Specifically, group.entries does NOT exists.
+	All items like groupname, the 3 items in the tuple are of type 'bytes'.
+	(That is because we read in binary mode. Reading in ASCII mde would fail as pwdb is not an ASCII file.)
+	vars(self.groups[list(self.groups.keys())[0]]): works
+	dict(self.groups[list(self.groups.keys())[0]]): fails, TypeError: 'PasswordGroup' object is not iterable
+
+	Case 3:
+	Py3 unpickling a Py3-pickled pwdb file sees the following:
+	groups = {'some groupname': <password_map.PasswordGroup object at 0x0fd06a4abed0>, ...}
+	with password_map.PasswordGroup being seen as:
+	{'entries': [('some username',
+		b'\xb7\x877\xb3\xf4\xaf\xa0\x91\xec\x7fOlr\x8fn\xf3\xed\x8b\x1a\x15\xc7\xc5\x14\xc7\xeb\xb2[\xb5l\xab\xe9\xc9\x97\x1b\xff\xac\x1a\xd1\xc3\xce\x1bXTH\x89\xef\x00Y',
+		b'_\xc2\x94B\x07]\x13\xc4\xaa)K\xb34`\xf5\xd9\xc0g\xefqX6\xa3\x95T5\\\xa9\x1eX\x19$\x02G\xaf8\x98\'\x05\xcc\xae\xb5^m\x0f\x92\x94\xcfI\xb9\xa1\xd2\xbfe2\x00E\xca\xf5\x84\xea\xcc\xe9\xaf+\xad\x90a\x06\x00Z7^\xe6\xc1EOn\xa5\x10mN\xf6\xdd\x92\x13\xe6[Ba\xe2\xa2iY2\x05\xc6\xc4\x9b\\^\xef"\x19O\xa3\xcd\xe4\xc5\x9eT\x80s\x81\xee\xc2$\x92\xfdQ\x86\xaf\xcf\x16\xb0<\xc3j\'\xf0G\x01\xa9\xcf;\xb1l\xcf\xcd4\xc6\x0cN\xba\xe4pK\xa4y\xf7\x01\xe8+v\x80\xa8<\xf8\x9f\xb4d\xb7\xe0\xb5\xbc^6\xc9J\\\xe3\x91\x9a\xa5\x08)\x0b\x958YI\xb5\xb7(W\xa5\xf8G\x02\x0f\x9c\x8dE\x0c*\\\xc9\x07\xaaW\xe3>\x93\x7f\x87\xe5\xff\xfe\x16G\xcf\x90\xd4\xd6?\xf0\x16\xa4\x93\xce\xd8\x9c\xf1\xff\x81`\xbf"W\xee\xfb\\[\xe5\x13\xd8[R\xec\xd2\xc6Erh\xdf\xdd\xebX\x8f\xf4[\x0e\x9d\xea\xa1\t;\xaf\x81\x8b\xc0\xb4\xa77\xde8v\xe4\x94\xf0\x87(\xa4\x87\x99\x9dCd\x08^\xb8\x84\x83E\x1a[/\xda\xc82,\xb4o\xea\x1cSI_\xb3\xd0t<\xe1\xea\xbb\x9c\n9IOuf\x95A\xec\xa7\xfa2>$\xb4\xea0\xcd\xc3\xa3\x1e\t&\x8cI\xfdqN0\xd1J\xebU>\xf1x\xc4\xb2\x0en\x8c\xaf\\B5b\xc9\xce\x87\xb4\x15\xbe\xe8e0\xe0\xa5@\x01Ib\xc3l#Z\xc7o%\xd9C\xac\xee\x16\xe1\xee\xba\xc3\xbe\x96\xdc\xba\xbc\xc4w\xb1\x7f\x02\x95\xcf(skt/\x84\x0b1\xb7\x14\\\xc6\x9e\xb4c\xcb\xc8\xb8\x8bY\'\x1a\xf6\xa35^\x1f\xba\x9c\x93\x8c\xa15\xbfdZ0\n\x9en{\xc0\xb5\x02>N\xee\xb2c\xc4\xcf\xb6\xc1Ot\xd7\x00\x0c\xb7\xc4x\x1dt\x92\'T*\xedW\xe7s\xed\x95J\x0f\xd8**"\xf4s\x1b\x1fK2\n\xb0\x8f\xb1P\xff\xa0\xe0\xdd\xd6\x94\x94ed\x1d\x07\xd7G\x99B]S\xa2\x8d\xe3\xd1\xa2Q`\xd6\x9b\x83'), ...]}
+	So, for Py3 this works again: tuple = pwMap.groups['some groupname'].entries[0]
+	Specifically, group.entries exists.
+	Groupname, and 0-element in tuple (key) are of type 'str' (unicode).
+	1-element (encPwCmt) and 2-element (encBackup) in the tuple are of type 'bytes'.
+
+	Case 4:
+	Py2 unpickling a Py3-pickled pwdb file sees the following:
+		Error: unsupported pickle protocol: 4
+		This is not supported. Py2 cannot open a Py3 pickled pwdb file.
+
+	@params groupsDictPy2: un unpickled password groups instance
+	@type groupsDictPy2: a Py2 version of unpickled dictionary {} of PasswordGroup instances
+	@returns: a dictionary {} of PasswordGroup instances apt for Py3
 	"""
 	if sys.version_info[0] < 3:  # Py2-vs-Py3:
 		raise RuntimeError(u"This code should only have been called with Python 3 or higher.")
 	settings.mlogger.log("Trying to migrate TrezorPass database \"%s\" "
-		"from Python 2 ro Python3." % settings.dbFilename, logging.DEBUG,
+		"from Python 2 to Python3." % settings.dbFilename, logging.DEBUG,
 		"TrezorPass database")
-	#### this function requires cleanup and documentation! zzz
-	# print(groupsDict)
-	groupsNew = {}  # PasswordGroup()
+	groupsDictPy3 = {}  # dictionary of PasswordGroup() instances
 	ii = 0
-	for groupName in groupsDict:
+	for groupName in groupsDictPy2:
 		ii += 1
-		#print('groupName %s' % (groupName))
-		pwGroup = groupsDict[groupName]
-		#print('\n pwGroup %s %s' % (pwGroup, type(pwGroup)))
-		#print('\n groupName %s %s' % (groupName, type(groupName)))  # Py2: str, Py3: bytes
-		groupsNew[normalize_nfc(groupName)] = PasswordGroup()
-		#print('groupsNew')
-		#pprint(groupsNew)
-		#pprint(dict(groupsNew))
-		#print('groupNew')
-		#pprint(groupsNew[normalize_nfc(groupName)])
-		#pprint(vars(groupsNew[normalize_nfc(groupName)]))
-		#print('pwGroup')
-		#pprint(vars(pwGroup))
-
+		# groupName is of type bytes
+		pwGroup = groupsDictPy2[groupName]
+		# pwGroup is of type PasswordGroup
+		# create and add a new empty group in Py3, convert groupname to type string.
+		groupsDictPy3[normalize_nfc(groupName)] = PasswordGroup()
+		# settings.mlogger.log("Password group %d read: \n%s" % (ii, vars(pwGroup)),
+		# 	logging.DEBUG, "TrezorPass database migration")
+		# since .entries member var does not exist, we use __dict__ to get to the data
 		mydict = pwGroup.__dict__
-
-		#print('\n mydict %s %s\n' % (mydict, type(mydict)))
+		# mydict has key b'entries', the corresponding value is of type list (of tuples)
+		# there is only 1 key in the mydict dictionary: key b'entries'
 		for instvarkey in mydict:
-			#print('\n instvarkey %s %s\n' % (instvarkey, type(instvarkey)))  # bytes
+			# type(instvarkey) returns bytes
 			instvarval = mydict[instvarkey]
-			#print('\n instvarval %s %s\n' % (instvarval, type(instvarval)))  # list
+			# type(instvarval) returns list
 			for triple in instvarval:
-				#print('\n triple %s %s\n' % (triple, type(triple)))  # tuple
+				# type(triple) returns tuple
+				# all 3 entries in tuple are of type 'bytes'
+				# entry 0 is the key, and we want that to be a 'string' (unicode)
+				# because that is displayed (e.g. 'login', or strings with foreign characters)
+				# entry 1 and 2 are encrypted values of pw+comments and backupPw.
+				# Since they are encrypted we want those 2 to remain of type 'bytes'
 				key, encPw, bkupPw = triple
-				groupsNew[normalize_nfc(groupName)].addEntry(normalize_nfc(key), encPw, bkupPw)
-				#print('groupNew')
-				#pprint(groupsNew[normalize_nfc(groupName)])
-				#pprint(vars(groupsNew[normalize_nfc(groupName)]))
-	#print("\n %d groups migrated." % (ii))
+				# add tuple to Py3 group
+				groupsDictPy3[normalize_nfc(groupName)].addEntry(normalize_nfc(key), encPw, bkupPw)
+		# settings.mlogger.log("Password group %d written: \n%s" %
+		# 	(ii, vars(groupsDictPy3[normalize_nfc(groupName)])), logging.DEBUG,
+		# 	"TrezorPass database migration")
 	settings.mlogger.log("%d password groups have been migrated "
-		"from Python 2 to Python3." % (ii), logging.DEBUG,
-		"TrezorPass database")
+		"from Python 2 to Python 3." % (ii), logging.DEBUG,
+		"TrezorPass database migration")
+	return(groupsDictPy3)
 
-	#pprint(groupsNew)
-	return(groupsNew)
+
+def migrateToUnicode(groupsDictBytes, settings):
+	"""
+	In an old version of TrezorPass groupName and key (0-element of tuple)
+	were in Py2 type 'str' (not in 'unicode') and did not allow
+	foreign characters. To fix this when we read the pwdb file
+	we must migrate from Py2 'str' to 'unicode'.
+
+	Takes an instance such as PasswordMap.groups
+	which is a dictionary of PasswordGroup instances.
+	Each PasswordGroup instance is an object with entries
+	which are lists of tuples.
+
+	Migrated unpickled pwdb data of groups from Py2 to Py3 format.
+	Takes an unpickled pwdb groups object in Py2 and
+	returns an unpickled pwdb groups object in Py3 format.
+
+	@params groupsDictBytes: un unpickled password groups instance
+	@type groupsDictBytes: a bytes (Py3) or str (py2) version of unpickled dictionary {} of PasswordGroup instances
+	@returns: a dictionary {} of PasswordGroup instances with groupName and key in str (Py3) or unicode (Py2)
+	"""
+	groupsDictStr = {}  # dictionary of PasswordGroup() instances
+	ii = 0
+	for groupName in groupsDictBytes:
+		ii += 1
+		# groupName is of type bytes
+		pwGroup = groupsDictBytes[groupName]
+		# pwGroup is of type PasswordGroup
+		# create and add a new empty group in Py3, convert groupname to type string.
+		groupsDictStr[normalize_nfc(groupName)] = PasswordGroup()
+		# settings.mlogger.log("Password group %d read: \n%s" % (ii, normalize_nfc(groupName)),
+		# 	logging.DEBUG, "TrezorPass database migration")
+		for entry in pwGroup.entries:
+			key, encPw, bkupPw = entry
+			# add tuple to Py3 group
+			groupsDictStr[normalize_nfc(groupName)].addEntry(normalize_nfc(key), encPw, bkupPw)
+	settings.mlogger.log("%d password groups have been migrated "
+		"to unicode." % (ii), logging.DEBUG,
+		"TrezorPass database migration")
+
+	return(groupsDictStr)

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,269 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import logging
+import getopt
+import os.path
+
+from PyQt5.QtWidgets import QMessageBox
+from PyQt5.QtCore import QT_VERSION_STR, QSettings
+from PyQt5.Qt import PYQT_VERSION_STR
+
+import basics
+import encoding
+from utils import BaseSettings, BaseArgs
+
+"""
+This is code that should be adapted to your applications.
+This code implements Settings and Argument parsing.
+
+Classes BaseSettings and BaseArgs from utils.py
+should be subclassed her as Settings and Args.
+
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
+
+
+class Settings(BaseSettings):
+	"""
+	Placeholder for settings
+	Settings such as command line options, GUI selected values,
+	user input, etc.
+	"""
+
+	def __init__(self, logger=None, mlogger=None):
+		"""
+		@param logger: holds logger for where to log info/warnings/errors
+			If None, a default logger will be created.
+		@type logger: L{logging.Logger}
+		@param mlogger: holds mlogger for where to log info/warnings/errors
+			If None, a default mlogger will be created.
+		@type mlogger: L{utils.MLogger}
+		"""
+		super(Settings, self).__init__(logger, mlogger)
+		self.dbFilename = None
+		self.qsettings = QSettings(u"ConstructibleUniverse", u"TrezorPass")
+		fname = self.qsettings.value(u"database/filename")
+		# returns None or unicode string
+		if fname is not None:
+			self.dbFilename = encoding.normalize_nfc(fname)
+		self.TArg = False
+		self.PArg = None
+		self.DArg = False
+		self.FArg = u""
+
+	def logSettings(self):
+		self.logger.debug(self.__str__())
+
+	def gui2Settings(self, dialog):
+		"""
+		This method should be implemented in the subclass.
+		Copy the settings info from the dialog GUI to the Settings instance.
+		"""
+		# self.input = dialog.input()
+		pass
+
+	def settings2Gui(self, dialog):
+		"""
+		This method should be implemented in the subclass.
+		Copy the settings info from the Settings instance to the dialog GUI.
+		"""
+		# dialog.setInput(self.input)
+		pass
+
+	def __str__(self):
+		return(super(Settings, self).__str__() + "\n" +
+			"settings.TArg = %s\n" % self.TArg +
+			"settings.PArg = %s\n" % u'***' +
+			"settings.DArg = %s\n" % self.DArg +
+			"settings.FArg = %s\n" % self.FArg +
+			"settings.dbFilename = %s\n" % self.dbFilename +
+			"QtCore.QSettings = %s" % self.qsettings.value(u"database/filename"))
+
+	def store(self):
+		self.qsettings.setValue(u"database/filename", self.dbFilename)
+
+	def passphrase(self):
+		return self.PArg
+
+
+class Args(BaseArgs):
+	"""
+	CLI Argument handling
+	"""
+
+	def __init__(self, settings, logger=None):
+		"""
+		Get all necessary parameters upfront, so the user
+		does not have to provide them later on each call.
+
+		@param settings: place to store settings
+		@type settings: L{Settings}
+		@param logger: holds logger for where to log info/warnings/errors
+			if no logger is given it uses the default logger of settings.
+			So, usually this would be None.
+		@type logger: L{logging.Logger}
+		"""
+		super(Args, self).__init__(settings, logger)
+
+	def printVersion(self):
+		super(Args, self).printVersion()
+		print("About " + basics.NAME + ": " + basics.NAME + " is a safe "
+			"Password Manager application \nfor people owning a Trezor who prefer "
+			"to keep their passwords local \nand not in the cloud. All passwords"
+			"are stored locally in a single file.")
+
+	def printUsage(self):
+		print('''TrezorPass.py [-v] [-h] [-l <level>] [-p <passphrase>] [[-d] -f <pwdbfile>]
+		-v, --version
+				print the version number
+		-h, --help
+				print short help text
+		-l, --logging
+				set logging level, integer from 1 to 5, 1=full logging, 5=no logging
+		-p, --passphrase
+				master passphrase used for Trezor.
+				It is recommended that you do not use this command line option
+				but rather give the passphrase through a small window interaction.
+		-f, --pwdbfile
+				name of an existing password file to use instead of the default one;
+				must be a valid TrezorPass password file
+		-d, --setdefault
+				set the file provided with `-f` as default, i.e. this will
+				be the password file opened from now on
+
+		All arguments are optional. Usually none needs to be used.
+
+		Examples:
+		# normal operation
+		TrezorPass.py
+
+		# normal operation with verbose logging at Debug level
+		TrezorPass.py -l 1
+
+		# open some old backup password database (once)
+		TrezorPass.py -f trezorpass.backup.170101.pwdb
+
+		# from now on always by default open password database from environment 2
+		TrezorPass.py -d -f trezorpass.env2.pwdb
+		''')
+
+	def parseArgs(self, argv, settings=None, logger=None):
+		"""
+		Parse the command line arguments and store the results in `settings`.
+		Report errors to `logger`.
+
+		@param settings: place to store settings;
+			if None the default settings from the Args class will be used.
+			So, usually this argument would be None.
+		@type settings: L{Settings}
+		@param logger: holds logger for where to log info/warnings/errors
+			if None the default logger from the Args class will be used.
+			So, usually this argument would be None.
+		@type logger: L{logging.Logger}
+		"""
+		# do not call super class parseArgs as partial parsing does not work
+		# superclass parseArgs is only useful if there are just -v -h -l [level]
+		# get defaults
+		if logger is None:
+			logger = self.logger
+		if settings is None:
+			settings = self.settings
+		try:
+			opts, args = getopt.getopt(argv, "vhl:p:df:",
+				["version", "help", "logging=", "passphrase=", "setdefault", "pwdbfile="])
+		except getopt.GetoptError as e:
+			logger.critical(u'Wrong arguments. Error: %s.', e)
+			try:
+				msgBox = QMessageBox(QMessageBox.Critical, u"Wrong arguments",
+					u"Error: %s" % e)
+				msgBox.exec_()
+			except Exception:
+				pass
+			sys.exit(2)
+		loglevelused = False
+		for opt, arg in opts:
+			if opt in ("-h", "--help"):
+				self.printUsage()
+				sys.exit()
+			elif opt in ("-v", "--version"):
+				self.printVersion()
+				sys.exit()
+			elif opt in ("-l", "--logging"):
+				loglevelarg = arg
+				loglevelused = True
+			elif opt in ("-t", "--terminal"):
+				settings.TArg = True
+			elif opt in ("-p", "--passphrase"):
+				settings.PArg = arg
+			elif opt in ("-d", "--setdefault"):
+				settings.DArg = True
+			elif opt in ("-f", "--pwdbfile"):
+				settings.FArg = arg
+
+		if loglevelused:
+			try:
+				loglevel = int(loglevelarg)
+			except Exception as e:
+				self.settings.mlogger.log(u"Logging level not specified correctly. "
+					"Must be integer between 1 and 5. (%s)" % loglevelarg, logging.CRITICAL,
+					"Wrong arguments", settings.TArg, logger)
+				sys.exit(18)
+			if loglevel > 5 or loglevel < 1:
+				self.settings.mlogger.log(u"Logging level not specified correctly. "
+					"Must be integer between 1 and 5. (%s)" % loglevelarg, logging.CRITICAL,
+					"Wrong arguments", settings.TArg, logger)
+				sys.exit(19)
+			settings.LArg = loglevel * 10  # https://docs.python.org/2/library/logging.html#levels
+		logger.setLevel(settings.LArg)
+
+		# for arg in args:
+		# 	# convert all input as possible to unicode UTF-8 NFC
+		# 	settings.inputArgs.append(encoding.normalize_nfc(arg))
+		# if len(args) >= 1:
+		# 	settings.input = args[0]
+		if len(args) != 0:
+			self.settings.mlogger.log("Incorrect arguments %s found in command line. "
+				"Correct your input." % (args), logging.ERROR,
+				"Wrong arguments", True, logger)
+			sys.exit(20)
+
+		if (settings.FArg == "") and settings.DArg:
+			self.settings.mlogger.log("Don't used `-d` without the `-f` argument. Aborting.",
+				logging.ERROR, "Wrong arguments", True, logger)
+			sys.exit(21)
+
+		if (settings.FArg != "") and not os.path.isfile(settings.FArg):
+			self.settings.mlogger.log("File \"%s\" does not exist, is not a proper file, "
+				"or is a directory. Aborting." % (settings.FArg), logging.ERROR,
+				"File IO Error", True, logger)
+			sys.exit(21)
+		elif (settings.FArg != "") and not os.access(settings.FArg, os.R_OK):
+			self.settings.mlogger.log("File \"%s\" cannot be read. No read permissions. "
+				"Aborting." % (settings.FArg), logging.ERROR, "File IO Error",
+				True, logger)
+			sys.exit(22)
+		elif settings.FArg != u"":
+			settings.dbFilename = settings.FArg
+			if settings.DArg:
+				settings.store()  # update/store permanently
+
+		settings.mlogger.setTerminalMode(settings.TArg)
+		self.settings.mlogger.log(u"%s Version: %s (%s)" %
+			(basics.NAME, basics.VERSION_STR, basics.VERSION_DATE_STR),
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u"Python: %s" % sys.version.replace(" \n", "; "),
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u"Qt Version: %s" % QT_VERSION_STR,
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u"PyQt Version: %s" % PYQT_VERSION_STR,
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u'Logging level set to %s (%d).' %
+			(logging.getLevelName(settings.LArg), settings.LArg),
+			logging.INFO, "Logging", True, logger)
+		self.settings.mlogger.log(settings,
+			logging.DEBUG, "Settings", True, logger)

--- a/trezor_app_generic.py
+++ b/trezor_app_generic.py
@@ -1,0 +1,267 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import getpass
+import logging
+
+from trezorlib.client import ProtocolMixin
+from trezorlib.transport_hid import HidTransport
+from trezorlib.client import BaseClient  # CallException, PinException
+from trezorlib import messages_pb2 as proto
+from trezorlib.transport import ConnectionError
+
+from trezor_gui import TrezorPassphraseDialog, TrezorPinDialog, TrezorChooserDialog
+
+import encoding
+
+"""
+This is generic code that should work untouched accross all applications.
+
+This code is written specifically such that both Terminal-only mode as well as
+GUI mode are supported for all 3 operations: Trezor choser, PIN entry,
+Passphrase entry.
+Each of the windows can be turned on or off individually with the 3 flags:
+readpinfromstdin, readpassphrasefromstdin, and readdevicestringfromstdin.
+
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
+
+
+"""
+Utility function to bridge Py2 and Py3 incompatibilities.
+Maps Py2 raw_input() to input() for Py2.
+Py2: raw_input()
+Py3: input()
+sys.version_info[0]
+Py2-vs-Py3:
+"""
+try:  # Py2-vs-Py3:
+	input = raw_input
+except NameError:
+	pass
+
+
+class QtTrezorMixin(object):
+	"""
+	Mixin for input of Trezor PIN and passhprases.
+	Works via both, terminal as well as PyQt GUI
+	"""
+
+	def __init__(self, *args, **kwargs):
+		super(QtTrezorMixin, self).__init__(*args, **kwargs)
+		self.passphrase = None
+		self.readpinfromstdin = None
+		self.readpassphrasefromstdin = None
+
+	def callback_ButtonRequest(self, msg):
+		return proto.ButtonAck()
+
+	def callback_PassphraseRequest(self, msg):
+		if self.passphrase is not None:
+			return proto.PassphraseAck(passphrase=str(self.passphrase))
+
+		if self.readpassphrasefromstdin:
+			# read passphrase from stdin
+			try:
+				passphrase = getpass.getpass(u"Please enter passphrase: ")
+				passphrase = encoding.normalize_nfc(passphrase)
+			except KeyboardInterrupt:
+				sys.stderr.write(u"\nKeyboard interrupt: passphrase not read. Aborting.\n")
+				sys.exit(3)
+			except Exception as e:
+				sys.stderr.write(u"Critical error: Passphrase not read. Aborting. (%s)" % e)
+				sys.exit(3)
+		else:
+			dialog = TrezorPassphraseDialog()
+			if not dialog.exec_():
+				sys.exit(3)
+			else:
+				passphrase = dialog.passphrase()
+
+		return proto.PassphraseAck(passphrase=passphrase)
+
+	def callback_PinMatrixRequest(self, msg):
+		if self.readpinfromstdin:
+			# read PIN from stdin
+			print(u"                  7  8  9")
+			print(u"                  4  5  6")
+			print(u"                  1  2  3")
+			try:
+				pin = getpass.getpass(u"Please enter PIN: ")
+			except KeyboardInterrupt:
+				sys.stderr.write(u"\nKeyboard interrupt: PIN not read. Aborting.\n")
+				sys.exit(7)
+			except Exception as e:
+				sys.stderr.write(u"Critical error: PIN not read. Aborting. (%s)" % e)
+				sys.exit(7)
+		else:
+			dialog = TrezorPinDialog()
+			if not dialog.exec_():
+				sys.exit(7)
+			pin = dialog.pin()
+
+		return proto.PinMatrixAck(pin=pin)
+
+	def prefillPassphrase(self, passphrase):
+		"""
+		Instead of asking for passphrase, use this one
+		"""
+		if passphrase is not None:
+			self.passphrase = encoding.normalize_nfc(passphrase)
+		else:
+			self.passphrase = None
+
+	def prefillReadpinfromstdin(self, readpinfromstdin=False):
+		"""
+		Specify if PIN should be read from stdin instead of from GUI
+		@param readpinfromstdin: True to force it to read from stdin, False otherwise
+		@type readpinfromstdin: C{bool}
+		"""
+		self.readpinfromstdin = readpinfromstdin
+
+	def prefillReadpassphrasefromstdin(self, readpassphrasefromstdin=False):
+		"""
+		Specify if passphrase should be read from stdin instead of from GUI
+		@param readpassphrasefromstdin: True to force it to read from stdin, False otherwise
+		@type readpassphrasefromstdin: C{bool}
+		"""
+		self.readpassphrasefromstdin = readpassphrasefromstdin
+
+
+class QtTrezorClient(ProtocolMixin, QtTrezorMixin, BaseClient):
+	"""
+	Trezor client with Qt input methods
+	"""
+	pass
+
+
+class TrezorChooser(object):
+	"""Class for working with Trezor device via HID"""
+
+	def __init__(self, readdevicestringfromstdin=False):
+		self.readdevicestringfromstdin = readdevicestringfromstdin
+
+	def getDevice(self):
+		"""
+		Get one from available devices. Widget will be shown if more
+		devices are available.
+		"""
+		devices = self.enumerateHIDDevices()
+		if not devices:
+			return None
+
+		transport = self.chooseDevice(devices)
+		client = QtTrezorClient(transport)
+		return client
+
+	def enumerateHIDDevices(self):
+		"""Returns Trezor HID devices"""
+		devices = HidTransport.enumerate()
+
+		return devices
+
+	def chooseDevice(self, devices):
+		"""
+		Choose device from enumerated list. If there's only one Trezor,
+		that will be chosen.
+
+		If there are multiple Trezors, diplays a widget with list
+		of Trezor devices to choose from.
+
+		devices is a list of device
+		A device is something like:
+		in Py2:  ['0001:0008:00', '0001:0008:01']
+		In Py3:  [b'0001:0008:00', b'0001:0008:01']
+
+		@returns HidTransport object of selected device
+		"""
+		if not len(devices):
+			raise RuntimeError(u"No Trezor connected!")
+
+		if len(devices) == 1:
+			try:
+				return HidTransport(devices[0])
+			except IOError:
+				raise RuntimeError(u"Trezor is currently in use")
+
+		# maps deviceId string to device label
+		deviceMap = {}
+		for device in devices:
+			try:
+				transport = HidTransport(device)
+				client = QtTrezorClient(transport)
+				label = client.features.label and client.features.label or "<no label>"
+				client.close()
+
+				deviceMap[device[0]] = label
+			except IOError:
+				# device in use, do not offer as choice
+				continue
+
+		if not deviceMap:
+			raise RuntimeError(u"All connected Trezors are in use!")
+
+		if self.readdevicestringfromstdin:
+			print(u'Chose your Trezor device please. '
+				'Devices currently in use are not listed:')
+			ii = 0
+			for device in deviceMap:
+				print('%d  %s' % (ii, deviceMap[device]))
+				ii += 1
+			ii -= 1
+			while True:
+				inputstr = input(u"Please provide the number of the device "
+					"chosen: (%d-%d, Carriage return to quit) " % (0, ii))
+
+				if inputstr == '':
+					raise RuntimeError(u"No Trezors device chosen! Quitting.")
+				try:
+					inputint = int(inputstr)
+				except Exception:
+					print(u'Wrong input. You must enter a number '
+						'between %d and %d. Try again.' % (0, ii))
+					continue
+				if inputint < 0 or inputint > ii:
+					print(u'Wrong input. You must enter a number '
+						'between %d and %d. Try again.' % (0, ii))
+					continue
+				break
+			# Py2-vs-Py3: dictionaries are different in Py2 and Py3
+			if sys.version_info[0] > 2:  # Py2-vs-Py3:
+				deviceStr = list(deviceMap.keys())[ii]
+			else:
+				deviceStr = deviceMap.keys()[ii]
+		else:
+			dialog = TrezorChooserDialog(deviceMap)
+			if not dialog.exec_():
+				raise RuntimeError(u"No Trezors device chosen! Quitting.")
+			deviceStr = dialog.chosenDeviceStr()
+		return HidTransport([deviceStr, None])
+
+
+def setupTrezor(readdevicestringfromstdin=False, mlogger=None):
+	"""
+	setup Trezor,
+	on error exit program
+	"""
+	try:
+		if mlogger is not None:
+			mlogger.log(u"Starting Trezor initialization", logging.DEBUG, u"Trezor Info")
+		trezorChooser = TrezorChooser(readdevicestringfromstdin)
+		trezor = trezorChooser.getDevice()
+	except (ConnectionError, RuntimeError) as e:
+		if mlogger is not None:
+			mlogger.log(u"Connection to Trezor failed: %s" % e,
+			logging.CRITICAL, u"Trezor Error")
+		sys.exit(1)
+
+	if trezor is None:
+		if mlogger is not None:
+			mlogger.log(u"No available Trezor found, quitting.",
+				logging.CRITICAL, u"Trezor Error")
+		sys.exit(1)
+	return trezor

--- a/trezor_chooser_dialog.ui
+++ b/trezor_chooser_dialog.ui
@@ -10,10 +10,16 @@
     <height>300</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>200</width>
+    <height>200</height>
+   </size>
+  </property>
   <property name="maximumSize">
    <size>
     <width>800</width>
-    <height>800</height>
+    <height>600</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -21,13 +27,26 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>icons/TrezorPass.svg</normaloff>icons/TrezorPass.svg</iconset>
+    <normaloff>icons/trezor.bg.svg</normaloff>icons/trezor.bg.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QLabel" name="logo">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap>icons/trezor.38x55.svg</pixmap>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Choose Trezor to use</string>
+      <string>Choose Trezor to use (only unused devices are listed)</string>
      </property>
     </widget>
    </item>

--- a/trezor_gui.py
+++ b/trezor_gui.py
@@ -1,0 +1,86 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from PyQt5.QtWidgets import QDialog, QListWidgetItem
+from PyQt5.QtCore import Qt, QVariant
+
+from ui_trezor_chooser_dialog import Ui_TrezorChooserDialog
+from ui_trezor_pin_dialog import Ui_TrezorPinDialog
+from ui_trezor_passphrase_dialog import Ui_TrezorPassphraseDialog
+
+import encoding
+
+"""
+This is generic code that should work untouched accross all applications.
+This code implements the Trezor IO in GUI mode.
+It covers all 3 operations: Trezor choser, PIN entry,
+Passphrase entry.
+
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
+
+
+class TrezorChooserDialog(QDialog, Ui_TrezorChooserDialog):
+
+	def __init__(self, deviceMap):
+		"""
+		Create dialog and fill it with labels from deviceMap
+
+		@param deviceMap: dict device string -> device label
+		"""
+		QDialog.__init__(self)
+		self.setupUi(self)
+
+		for deviceStr, label in deviceMap.items():
+			item = QListWidgetItem(label)
+			item.setData(Qt.UserRole, QVariant(deviceStr))
+			self.trezorList.addItem(item)
+		self.trezorList.setCurrentRow(0)
+
+	def chosenDeviceStr(self):
+		"""
+		Returns device string of chosen Trezor
+		in Py3: must return str, i.e. bytes; not unicode!
+		"""
+		itemData = self.trezorList.currentItem().data(Qt.UserRole)
+		deviceStr = encoding.tobytes(itemData)
+		return deviceStr
+
+
+class TrezorPassphraseDialog(QDialog, Ui_TrezorPassphraseDialog):
+
+	def __init__(self):
+		QDialog.__init__(self)
+		self.setupUi(self)
+
+	def passphrase(self):
+		return encoding.normalize_nfc(self.passphraseEdit.text())
+
+
+class TrezorPinDialog(QDialog, Ui_TrezorPinDialog):
+
+	def __init__(self):
+		QDialog.__init__(self)
+		self.setupUi(self)
+
+		self.pb1.clicked.connect(self.pinpadPressed)
+		self.pb2.clicked.connect(self.pinpadPressed)
+		self.pb3.clicked.connect(self.pinpadPressed)
+		self.pb4.clicked.connect(self.pinpadPressed)
+		self.pb5.clicked.connect(self.pinpadPressed)
+		self.pb6.clicked.connect(self.pinpadPressed)
+		self.pb7.clicked.connect(self.pinpadPressed)
+		self.pb8.clicked.connect(self.pinpadPressed)
+		self.pb9.clicked.connect(self.pinpadPressed)
+
+	def pin(self):
+		return encoding.normalize_nfc(self.pinEdit.text())
+
+	def pinpadPressed(self):
+		sender = self.sender()
+		objName = sender.objectName()
+		digit = objName[-1]
+		self.pinEdit.setText(self.pinEdit.text() + digit)

--- a/trezor_passphrase_dialog.ui
+++ b/trezor_passphrase_dialog.ui
@@ -7,19 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>124</height>
+    <height>180</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>0</width>
-    <height>0</height>
+    <width>200</width>
+    <height>180</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>800</width>
-    <height>800</height>
+    <width>400</width>
+    <height>180</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -27,9 +27,25 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>icons/TrezorPass.svg</normaloff>icons/TrezorPass.svg</iconset>
+    <normaloff>icons/trezor.bg.svg</normaloff>icons/trezor.bg.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="logo">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap>icons/trezor.38x55.svg</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
@@ -39,23 +55,16 @@
    </item>
    <item>
     <widget class="QLineEdit" name="passphraseEdit">
+     <property name="inputMethodHints">
+      <set>Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
+     </property>
+     <property name="maxLength">
+      <number>1024</number>
+     </property>
      <property name="echoMode">
       <enum>QLineEdit::Password</enum>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/trezor_pin_dialog.ui
+++ b/trezor_pin_dialog.ui
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>EnterPinDialog</class>
- <widget class="QDialog" name="EnterPinDialog">
+ <class>TrezorPinDialog</class>
+ <widget class="QDialog" name="TrezorPinDialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>340</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>180</width>
+    <height>300</height>
+   </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>500</width>
-    <height>400</height>
+    <width>400</width>
+    <height>360</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -21,9 +27,25 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>icons/TrezorPass.svg</normaloff>icons/TrezorPass.svg</iconset>
+    <normaloff>icons/trezor.bg.svg</normaloff>icons/trezor.bg.svg</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="logo">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="pixmap">
+      <pixmap>icons/trezor.38x55.svg</pixmap>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
@@ -68,6 +90,12 @@
      </item>
      <item row="4" column="0" colspan="3">
       <widget class="QLineEdit" name="pinEdit">
+       <property name="inputMethodHints">
+        <set>Qt::ImhDigitsOnly|Qt::ImhHiddenText|Qt::ImhNoAutoUppercase|Qt::ImhNoPredictiveText|Qt::ImhSensitiveData</set>
+       </property>
+       <property name="maxLength">
+        <number>9</number>
+       </property>
        <property name="echoMode">
         <enum>QLineEdit::Password</enum>
        </property>
@@ -147,7 +175,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>EnterPinDialog</receiver>
+   <receiver>TrezorPinDialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -163,7 +191,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>EnterPinDialog</receiver>
+   <receiver>TrezorPinDialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,437 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+import logging
+import getopt
+
+from PyQt5.QtWidgets import QMessageBox
+from PyQt5.QtCore import QT_VERSION_STR
+from PyQt5.Qt import PYQT_VERSION_STR
+
+import basics
+
+"""
+This is generic code that should work untouched accross all applications.
+This code implements Logging for both Terminal and GUI mode.
+It implements Settings and Argument parsing.
+
+Code should work on both Python 2.7 as well as 3.4.
+Requires PyQt5.
+(Old version supported PyQt4.)
+"""
+
+
+def input23(prompt=u''):  # Py2-vs-Py3: 
+	"""
+	Utility function to bridge Py2 and Py3 incompatibilities.
+	Maps Py2 raw_input() to input() for Py2.
+	Py2: raw_input()
+	Py3: input()
+	"""
+	if sys.version_info[0] < 3:  # Py2-vs-Py3:
+		return raw_input(prompt)
+	else:
+		return input(prompt)
+
+
+class MLogger(object):
+	"""
+	class for logging that covers, print, logger, and writing to GUI QTextBrowser widget.
+	Its is called *M*Logger because it can log to *M*ultiple streams
+	such as stdout, QTextBrowser, msgBox, ...
+	Alternatively, he MLogger could have been implemented according to this
+	strategy: https://stackoverflow.com/questions/24469662/how-to-redirect-logger-output-into-pyqt-text-widget
+	"""
+
+	def __init__(self, terminalMode=None, logger=None, qtextbrowser=None):
+		"""
+		Get as many necessary parameters upfront as possible, so the user
+		does not have to provide them later on each call.
+
+		@param terminalMode: log only to terminal?
+		@type terminalMode: C{bool}
+		@param logger: holds logger for where to log info/warnings/errors
+		@type logger: L{logging.Logger}
+		@param qtextbrowser: holds GUI widget for where to log info/warnings/errors
+		@type qtextbrowser: L{PyQt5.QtWidgets.QTextBrowser}
+		"""
+		self.terminalMode = terminalMode
+		self.logger = logger
+		self.qtextbrowser = qtextbrowser
+		# qtextbrowser text will be created by assembling:
+		# qtextheader + qtextContent + qtextTrailer
+		self.qtextheader = u''
+		self.qtextcontent = u''
+		self.qtexttrailer = u''
+
+	def setTerminalMode(self, terminalMode):
+		self.terminalMode = terminalMode
+
+	def setLogger(self, logger):
+		self.logger = logger
+
+	def setQtextbrowser(self, qtextbrowser):
+		"""
+		@param qtextbrowser: holds GUI widget for where to log info/warnings/errors
+		@type qtextbrowser: L{PyQt5.QtWidgets.QTextBrowser}
+		"""
+		self.qtextbrowser = qtextbrowser
+
+	def setQtextheader(self, str):
+		"""
+		@param str: string to report/log
+		@type str: C{string}
+		"""
+		self.qtextheader = str
+
+	def setQtextcontent(self, str):
+		"""
+		@param str: string to report/log
+		@type str: C{string}
+		"""
+		self.qtextcontent = str
+
+	def appendQtextcontent(self, str):
+		"""
+		@param str: string to report/log
+		@type str: C{string}
+		"""
+		self.qtextcontent += str
+
+	def setQtexttrailer(self, str):
+		"""
+		@param str: string to report/log
+		@type str: C{string}
+		"""
+		self.qtexttrailer = str
+
+	def qtext(self):
+		return self.qtextheader + self.qtextcontent + self.qtexttrailer
+
+	def moveCursorToBottomQtext(self):
+		# move the cursor to the end of the text, scroll to the bottom
+		cursor = self.qtextbrowser.textCursor()
+		cursor.setPosition(len(self.qtextbrowser.toPlainText()))
+		self.qtextbrowser.ensureCursorVisible()
+		self.qtextbrowser.setTextCursor(cursor)
+
+	def publishQtext(self):
+		self.qtextbrowser.setHtml(self.qtext())
+		self.moveCursorToBottomQtext()
+
+	def log(self, str, level, title, terminalMode=None, logger=None, qtextbrowser=None):
+		"""
+		Displays string `str` depending on scenario:
+		a) in terminal mode: thru logger (except if loglevel == NOTSET)
+		b) in GUI mode and GUI window open: (qtextbrowser!=None) in qtextbrowser of GUI window
+		c) in GUI mode but window still/already closed: (qtextbrowser==None) thru QMessageBox()
+
+		If terminalMode=None, logger=None, qtextbrowser=None, then the
+		corresponding value from self is used. So, None means this
+		value should default to the preset value of the class Log.
+
+		@param str: string to report/log
+		@type str: C{string}
+		@param level: log level from DEBUG to CRITICAL from L{logging}
+		@type level: C{int}
+		@param title: window title text (only used if there is a window)
+		@type title: C{string}
+
+		@param terminalMode: log only to terminal?
+		@type terminalMode: C{bool}
+		@param logger: holds logger for where to log info/warnings/errors
+		@type logger: L{logging.Logger}
+		@param qtextbrowser: holds GUI widget for where to log info/warnings/errors
+		@type qtextbrowser: L{PyQt5.QtWidgets.QTextBrowser}
+		"""
+		# get defaults
+		if terminalMode is None:
+			terminalMode = self.terminalMode
+		if logger is None:
+			logger = self.logger
+		if qtextbrowser is None:
+			qtextbrowser = self.qtextbrowser
+		# initialize
+		if logger is None:
+			logging.basicConfig(stream=sys.stderr, level=basics.DEFAULT_LOG_LEVEL)
+			logger = logging.getLogger(basics.LOGGER_ACRONYM)
+		if qtextbrowser is None:
+			guiExists = False
+		else:
+			guiExists = True
+		if guiExists:
+			if terminalMode is None:
+				terminalMode = False
+		else:
+			if terminalMode is None:
+				terminalMode = True
+		if level == logging.NOTSET:
+			if terminalMode:
+				print(str)  # stdout
+			elif guiExists:
+				print(str)  # stdout
+				self.appendQtextcontent(u"<br>%s" % (str))
+			else:
+				print(str)  # stdout
+				try:
+					msgBox = QMessageBox(QMessageBox.Information,
+						title, u"%s" % (str))
+					msgBox.exec_()
+				except Exception:
+					pass
+		elif level == logging.DEBUG:
+			if terminalMode:
+				logger.debug(str)
+			elif guiExists:
+				logger.debug(str)
+				if logger.getEffectiveLevel() <= level:
+					self.appendQtextcontent(u"<br>Debug: %s" % str)
+			else:
+				# don't spam the user with too many pop-ups
+				# For debug, instead of a pop-up we write to stdout
+				logger.debug(str)
+		elif level == logging.INFO:
+			if terminalMode:
+				logger.info(str)
+			elif guiExists:
+				logger.info(str)
+				if logger.getEffectiveLevel() <= level:
+					self.appendQtextcontent(u"<br>Info: %s" % (str))
+			else:
+				logger.info(str)
+				if logger.getEffectiveLevel() <= level:
+					try:
+						msgBox = QMessageBox(QMessageBox.Information,
+							title, u"Info: %s" % (str))
+						msgBox.exec_()
+					except Exception:
+						pass
+		elif level == logging.WARNING:
+			if terminalMode:
+				logger.warning(str)
+			elif guiExists:
+				logger.warning(str)
+				if logger.getEffectiveLevel() <= level:
+					self.appendQtextcontent(u"<br>Warning: %s" % (str))
+			else:
+				logger.warning(str)
+				if logger.getEffectiveLevel() <= level:
+					try:
+						msgBox = QMessageBox(QMessageBox.Warning,
+							title, u"Warning: %s" % (str))
+						msgBox.exec_()
+					except Exception:
+						pass
+		elif level == logging.ERROR:
+			if terminalMode:
+				logger.error(str)
+			elif guiExists:
+				logger.error(str)
+				if logger.getEffectiveLevel() <= level:
+					self.appendQtextcontent(u"<br>Error: %s" % (str))
+			else:
+				logger.error(str)
+				if logger.getEffectiveLevel() <= level:
+					try:
+						msgBox = QMessageBox(QMessageBox.Critical,
+							title, u"Error: %s" % (str))
+						msgBox.exec_()
+					except Exception:
+						pass
+		elif level == logging.CRITICAL:
+			if terminalMode:
+				logger.critical(str)
+			elif guiExists:
+				logger.critical(str)
+				if logger.getEffectiveLevel() <= level:
+					self.appendQtextcontent(u"<br>Critical: %s" % (str))
+			else:
+				logger.critical(str)
+				if logger.getEffectiveLevel() <= level:
+					try:
+						msgBox = QMessageBox(QMessageBox.Critical,
+							title, u"Critical: %s" % (str))
+						msgBox.exec_()
+					except Exception:
+						pass
+		if qtextbrowser is not None:
+			# flush changes to GUI
+			self.publishQtext()
+
+
+class BaseSettings(object):
+	"""
+	Placeholder for settings
+	Settings such as command line options, GUI selected values,
+	user input, etc.
+	This class is supposed to be subclassed, e.g. as Settings
+	to adapt to the specifics of the application.
+	"""
+
+	def __init__(self, logger=None, mlogger=None):
+		"""
+		@param logger: holds logger for where to log info/warnings/errors
+			If None, a default logger will be created.
+		@type logger: L{logging.Logger}
+		@param mlogger: holds mlogger for where to log info/warnings/errors
+			If None, a default mlogger will be created.
+		@type mlogger: L{utils.MLogger}
+		"""
+		self.VArg = False
+		self.HArg = False
+		self.LArg = basics.DEFAULT_LOG_LEVEL
+
+		if logger is None:
+			logging.basicConfig(stream=sys.stderr, level=basics.DEFAULT_LOG_LEVEL)
+			self.logger = logging.getLogger(basics.LOGGER_ACRONYM)
+		else:
+			self.logger = logger
+
+		if mlogger is None:
+			self.mlogger = MLogger(terminalMode=None, logger=self.logger, qtextbrowser=None)
+		else:
+			self.mlogger = mlogger
+
+	def logSettings(self):
+		self.logger.debug(self.__str__())
+
+	def gui2Settings(self, dialog):
+		"""
+		This method should be implemented in the subclass.
+		Copy the settings info from the dialog GUI to the Settings instance.
+		"""
+		pass
+
+	def settings2Gui(self, dialog):
+		"""
+		This method should be implemented in the subclass.
+		Copy the settings info from the Settings instance to the dialog GUI.
+		"""
+		pass
+
+	def __str__(self):
+		return("settings.VArg = %s\n" % self.VArg +
+			"settings.HArg = %s\n" % self.HArg +
+			"settings.LArg = %s" % self.LArg)
+
+
+class BaseArgs(object):
+	"""
+	CLI Argument handling
+	This class is supposed to be subclassed, e.g. as Args
+	to adapt to the specifics of the application.
+	"""
+
+	def __init__(self, settings, logger=None):
+		"""
+		Get all necessary parameters upfront, so the user
+		does not have to provide them later on each call.
+
+		@param settings: place to store settings
+		@type settings: L{Settings}
+		@param logger: holds logger for where to log info/warnings/errors
+			if no logger is given it uses the default logger of settings.
+			So, usually this would be None.
+		@type logger: L{logging.Logger}
+		"""
+		self.settings = settings
+		if logger is None:
+			self.logger = settings.logger
+		else:
+			self.logger = logger
+
+	def printVersion(self):
+		print(u"%s Version: %s (%s)" % (basics.NAME, basics.VERSION_STR, basics.VERSION_DATE_STR))
+		print(u"Python: %s" % sys.version.replace(" \n", "; "))
+		print(u"Qt Version: %s" % QT_VERSION_STR)
+		print(u"PyQt Version: %s" % PYQT_VERSION_STR)
+
+	def printUsage(self):
+		"""
+		This method should be implemented in the subclass.
+		"""
+		print(basics.NAME + '''.py [-h] [-v] [-l <loglevel>]
+		-v, --version
+				Print the version number
+		-h, --help
+			Print help text
+		-l, --logging
+			Set logging level, integer from 1 to 5, 1=full logging, 5=no logging
+		''')
+
+	def parseArgs(self, argv, settings=None, logger=None):
+		"""
+		Parse the command line arguments and store the results in `settings`.
+		Report errors to `logger`.
+
+		This method should be implemented in the subclass.
+		Calling this method is only useful when the application has exactly
+		the 3 arguments -h -v -l [level]
+
+		@param settings: place to store settings;
+			if None the default settings from the Args class will be used.
+			So, usually this argument would be None.
+		@type settings: L{Settings}
+		@param logger: holds logger for where to log info/warnings/errors
+			if None the default logger from the Args class will be used.
+			So, usually this argument would be None.
+		@type logger: L{logging.Logger}
+		"""
+		# get defaults
+		if logger is None:
+			logger = self.logger
+		if settings is None:
+			settings = self.settings
+		try:
+			opts, args = getopt.getopt(argv, "vhl:",
+				["version", "help", "logging="])
+		except getopt.GetoptError as e:
+			msgBox = QMessageBox(QMessageBox.Critical, u"Wrong arguments",
+				u"Error: %s" % e)
+			msgBox.exec_()
+			logger.critical(u'Wrong arguments. Error: %s.', e)
+			sys.exit(2)
+		loglevelused = False
+		for opt, arg in opts:
+			if opt in ("-h", "--help"):
+				self.printUsage()
+				sys.exit()
+			elif opt in ("-v", "--version"):
+				self.printVersion()
+				sys.exit()
+			elif opt in ("-l", "--logging"):
+				loglevelarg = arg
+				loglevelused = True
+
+		if loglevelused:
+			try:
+				loglevel = int(loglevelarg)
+			except Exception:
+				self.settings.mlogger.log(u"Logging level not specified correctly. "
+					"Must be integer between 1 and 5. (%s)" % loglevelarg, logging.CRITICAL,
+					"Wrong arguments", True, logger)
+				sys.exit(18)
+			if loglevel > 5 or loglevel < 1:
+				self.settings.mlogger.log(u"Logging level not specified correctly. "
+					"Must be integer between 1 and 5. (%s)" % loglevelarg, logging.CRITICAL,
+					"Wrong arguments", True, logger)
+				sys.exit(19)
+			settings.LArg = loglevel * 10  # https://docs.python.org/2/library/logging.html#levels
+		logger.setLevel(settings.LArg)
+
+		self.settings.mlogger.log(u"%s Version: %s (%s)" %
+			(basics.NAME, basics.VERSION_STR, basics.VERSION_DATE_STR),
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u"Python: %s" % sys.version.replace(" \n", "; "),
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u"Qt Version: %s" % QT_VERSION_STR,
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u"PyQt Version: %s" % PYQT_VERSION_STR,
+			logging.INFO, "Version", True, logger)
+		self.settings.mlogger.log(u'Logging level set to %s (%d).' %
+			(logging.getLevelName(settings.LArg), settings.LArg),
+			logging.INFO, "Logging", True, logger)
+		self.settings.mlogger.log(settings,
+			logging.DEBUG, "Settings", True, logger)


### PR DESCRIPTION
* Ported TrezorPass to from Python 2.7 to Python 3.4+. 
* It works now on both, Python 2.7 and Python 3.4+. 
* Ported from PyQt4 and Qt4 to PyQt5 and Qt5. 
* It does no longer support PyQt4/Qt4.
* Unicode character can now be used everywhere: groupnames, keys, passwords, comments, csv import fields, csv export fields, etc.
* Bug fixes: csv export did not handle "\ pattern correctly
* Miscellaneous improvements. 
* Improved inline documentation
* improved logging